### PR TITLE
docs: apply flags to coverage badges

### DIFF
--- a/apps/barry/README.md
+++ b/apps/barry/README.md
@@ -135,7 +135,7 @@ Please note that the licenses may differ between different parts of the project.
 
 <!-- Image References -->
 [badge-build]:https://img.shields.io/github/actions/workflow/status/HeadTriXz/Barry/test.yml?branch=main&style=for-the-badge
-[badge-coverage]:https://img.shields.io/codecov/c/github/HeadTriXz/Barry?style=for-the-badge
+[badge-coverage]:https://img.shields.io/codecov/c/github/HeadTriXz/Barry?style=for-the-badge&flag=barry
 [badge-contribute]:https://img.shields.io/badge/contributions-welcome-orange.svg?style=for-the-badge
 [badge-kofi]:https://ko-fi.com/img/githubbutton_sm.svg
 [badge-license]:https://img.shields.io/badge/license-AGPL%20v3-blue.svg?style=for-the-badge

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -101,7 +101,7 @@ Please note that the licenses may differ between different parts of the project.
 
 <!-- Image References -->
 [badge-build]:https://img.shields.io/github/actions/workflow/status/HeadTriXz/Barry/test.yml?branch=main&style=for-the-badge
-[badge-coverage]:https://img.shields.io/codecov/c/github/HeadTriXz/Barry?style=for-the-badge
+[badge-coverage]:https://img.shields.io/codecov/c/github/HeadTriXz/Barry?style=for-the-badge&flag=core
 [badge-contribute]:https://img.shields.io/badge/contributions-welcome-orange.svg?style=for-the-badge
 [badge-kofi]:https://ko-fi.com/img/githubbutton_sm.svg
 [badge-license]:https://img.shields.io/badge/license-MIT-blue.svg?style=for-the-badge

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -73,7 +73,7 @@ Please note that the licenses may differ between different parts of the project.
 
 <!-- Image References -->
 [badge-build]:https://img.shields.io/github/actions/workflow/status/HeadTriXz/Barry/test.yml?branch=main&style=for-the-badge
-[badge-coverage]:https://img.shields.io/codecov/c/github/HeadTriXz/Barry?style=for-the-badge
+[badge-coverage]:https://img.shields.io/codecov/c/github/HeadTriXz/Barry?style=for-the-badge&flag=logger
 [badge-contribute]:https://img.shields.io/badge/contributions-welcome-orange.svg?style=for-the-badge
 [badge-kofi]:https://ko-fi.com/img/githubbutton_sm.svg
 [badge-license]:https://img.shields.io/badge/license-MIT-blue.svg?style=for-the-badge

--- a/packages/music/README.md
+++ b/packages/music/README.md
@@ -4,7 +4,6 @@
 [![Banner Barry][banner]][link-repo]
 
 [![Build][badge-build]][link-build]
-[![Coverage][badge-coverage]][link-coverage]
 [![Contribute][badge-contribute]][link-contributing]
 [![License][badge-license]][link-license]
 
@@ -28,7 +27,6 @@ Please note that the licenses may differ between different parts of the project.
 
 <!-- Image References -->
 [badge-build]:https://img.shields.io/github/actions/workflow/status/HeadTriXz/Barry/test.yml?branch=main&style=for-the-badge
-[badge-coverage]:https://img.shields.io/codecov/c/github/HeadTriXz/Barry?style=for-the-badge
 [badge-contribute]:https://img.shields.io/badge/contributions-welcome-orange.svg?style=for-the-badge
 [badge-kofi]:https://ko-fi.com/img/githubbutton_sm.svg
 [badge-license]:https://img.shields.io/badge/license-MIT-blue.svg?style=for-the-badge
@@ -36,7 +34,6 @@ Please note that the licenses may differ between different parts of the project.
 
 <!-- Badge References -->
 [link-build]:https://github.com/HeadTriXz/Barry/actions
-[link-coverage]:https://codecov.io/gh/HeadTriXz/Barry
 
 <!-- Links -->
 [link-contributing]:https://github.com/HeadTriXz/Barry/blob/main/.github/CONTRIBUTING.md

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -4,7 +4,6 @@
 [![Banner Barry][banner]][link-repo]
 
 [![Build][badge-build]][link-build]
-[![Coverage][badge-coverage]][link-coverage]
 [![Contribute][badge-contribute]][link-contributing]
 [![License][badge-license]][link-license]
 
@@ -28,7 +27,6 @@ Please note that the licenses may differ between different parts of the project.
 
 <!-- Image References -->
 [badge-build]:https://img.shields.io/github/actions/workflow/status/HeadTriXz/Barry/test.yml?branch=main&style=for-the-badge
-[badge-coverage]:https://img.shields.io/codecov/c/github/HeadTriXz/Barry?style=for-the-badge
 [badge-contribute]:https://img.shields.io/badge/contributions-welcome-orange.svg?style=for-the-badge
 [badge-kofi]:https://ko-fi.com/img/githubbutton_sm.svg
 [badge-license]:https://img.shields.io/badge/license-MIT-blue.svg?style=for-the-badge
@@ -36,7 +34,6 @@ Please note that the licenses may differ between different parts of the project.
 
 <!-- Badge References -->
 [link-build]:https://github.com/HeadTriXz/Barry/actions
-[link-coverage]:https://codecov.io/gh/HeadTriXz/Barry
 
 <!-- Links -->
 [link-contributing]:https://github.com/HeadTriXz/Barry/blob/main/.github/CONTRIBUTING.md


### PR DESCRIPTION
Adds the right flag to each badge to see the coverage of the package (rather than average). Also removes the badge for the packages without tests.