### PR TITLE
feat: allow multiple component IDs in awaitMessageComponent

### DIFF
--- a/packages/core/src/interactions/ReplyableInteraction.ts
+++ b/packages/core/src/interactions/ReplyableInteraction.ts
@@ -54,13 +54,13 @@ export class ReplyableInteraction extends Interaction {
      * Waits for a message component response with the specified message and custom ID.
      *
      * @param messageID The ID of the message to listen for.
-     * @param customID The custom ID to match.
+     * @param customIDs An array of custom IDs to match.
      * @param timeout The timeout duration in milliseconds (default: 15 minutes).
      * @returns The matching MessageComponentInteraction or undefined if timed out.
      */
     async awaitMessageComponent(
         messageID: string,
-        customID: string | string[],
+        customIDs: string[],
         timeout: number = 15 * 60 * 1000
     ): Promise<MessageComponentInteraction | void> {
         return new Promise<MessageComponentInteraction | void>((resolve) => {
@@ -69,11 +69,7 @@ export class ReplyableInteraction extends Interaction {
                     return;
                 }
 
-                const toMatch = typeof customID === "string"
-                    ? [customID]
-                    : customID;
-
-                if (interaction.message.id === messageID && toMatch.includes(interaction.data.customID)) {
+                if (interaction.message.id === messageID && customIDs.includes(interaction.data.customID)) {
                     this.#client.off(GatewayDispatchEvents.InteractionCreate, listener);
                     resolve(interaction);
                 }

--- a/packages/core/src/interactions/ReplyableInteraction.ts
+++ b/packages/core/src/interactions/ReplyableInteraction.ts
@@ -60,7 +60,7 @@ export class ReplyableInteraction extends Interaction {
      */
     async awaitMessageComponent(
         messageID: string,
-        customID: string,
+        customID: string | string[],
         timeout: number = 15 * 60 * 1000
     ): Promise<MessageComponentInteraction | void> {
         return new Promise<MessageComponentInteraction | void>((resolve) => {
@@ -69,7 +69,11 @@ export class ReplyableInteraction extends Interaction {
                     return;
                 }
 
-                if (interaction.message.id === messageID && interaction.data.customID === customID) {
+                const toMatch = typeof customID === "string"
+                    ? [customID]
+                    : customID;
+
+                if (interaction.message.id === messageID && toMatch.includes(interaction.data.customID)) {
                     this.#client.off(GatewayDispatchEvents.InteractionCreate, listener);
                     resolve(interaction);
                 }

--- a/packages/core/tests/interactions/ReplyableInteraction.test.ts
+++ b/packages/core/tests/interactions/ReplyableInteraction.test.ts
@@ -50,20 +50,7 @@ describe("ReplyableInteraction", () => {
 
             const data = createMockMessageComponentInteraction();
             const response = InteractionFactory.from(data, client);
-            const promise = interaction.awaitMessageComponent("91256340920236565", "button");
-
-            client.emit(GatewayDispatchEvents.InteractionCreate, response);
-
-            await expect(promise).resolves.toBe(response);
-            expect(offSpy).toHaveBeenCalledOnce();
-        });
-
-        it("should resolve with a MessageComponentInteraction if it matches one of the components", async () => {
-            const offSpy = vi.spyOn(client, "off");
-
-            const data = createMockMessageComponentInteraction();
-            const response = InteractionFactory.from(data, client);
-            const promise = interaction.awaitMessageComponent("91256340920236565", ["select", "button"]);
+            const promise = interaction.awaitMessageComponent("91256340920236565", ["button"]);
 
             client.emit(GatewayDispatchEvents.InteractionCreate, response);
 
@@ -75,7 +62,7 @@ describe("ReplyableInteraction", () => {
             vi.useFakeTimers();
 
             const offSpy = vi.spyOn(client, "off");
-            const promise = interaction.awaitMessageComponent("91256340920236565", "button", 2000);
+            const promise = interaction.awaitMessageComponent("91256340920236565", ["button"], 2000);
 
             vi.advanceTimersByTime(3000);
 
@@ -90,7 +77,7 @@ describe("ReplyableInteraction", () => {
 
             const data = createMockApplicationCommandInteraction();
             const response = InteractionFactory.from(data, client);
-            const promise = interaction.awaitMessageComponent("91256340920236565", "button", 2000);
+            const promise = interaction.awaitMessageComponent("91256340920236565", ["button"], 2000);
 
             client.emit(GatewayDispatchEvents.InteractionCreate, response);
             vi.advanceTimersByTime(3000);

--- a/packages/core/tests/interactions/ReplyableInteraction.test.ts
+++ b/packages/core/tests/interactions/ReplyableInteraction.test.ts
@@ -58,6 +58,19 @@ describe("ReplyableInteraction", () => {
             expect(offSpy).toHaveBeenCalledOnce();
         });
 
+        it("should resolve with a MessageComponentInteraction if it matches one of the components", async () => {
+            const offSpy = vi.spyOn(client, "off");
+
+            const data = createMockMessageComponentInteraction();
+            const response = InteractionFactory.from(data, client);
+            const promise = interaction.awaitMessageComponent("91256340920236565", ["select", "button"]);
+
+            client.emit(GatewayDispatchEvents.InteractionCreate, response);
+
+            await expect(promise).resolves.toBe(response);
+            expect(offSpy).toHaveBeenCalledOnce();
+        });
+
         it("should resolve with undefined if the timeout is reached", async () => {
             vi.useFakeTimers();
 


### PR DESCRIPTION
You can now listen for multiple components on a message, rather than just one.