### PR TITLE
feat(barry): add new reverse search commands

### DIFF
--- a/apps/barry/src/config.ts
+++ b/apps/barry/src/config.ts
@@ -47,8 +47,13 @@ class Emoji {
 
 export default {
     emotes: {
+        bing: new Emoji("bing", "1127741749016657980"),
         check: new Emoji("check", "1004436175307669659"),
-        error: new Emoji("error", "1004436176859578510")
+        error: new Emoji("error", "1004436176859578510"),
+        googleLens: new Emoji("googlelens", "1127735623948705852"),
+        next: new Emoji("next", "1124406938738905098"),
+        previous: new Emoji("previous", "1124406936188768357"),
+        yandex: new Emoji("yandex", "1005213772199251988")
     },
     defaultColor: 0xFFC331,
     embedColor: 0x2F3136

--- a/apps/barry/src/index.ts
+++ b/apps/barry/src/index.ts
@@ -1,6 +1,6 @@
 import { Client, FastifyServer } from "@barry/core";
 
-import { loadModules } from "./utils.js";
+import { loadModules } from "./utils/index.js";
 import { API } from "@discordjs/core";
 import { Logger } from "@barry/logger";
 import { REST } from "@discordjs/rest";

--- a/apps/barry/src/modules/general/commands/chatinput/reverse/image/index.ts
+++ b/apps/barry/src/modules/general/commands/chatinput/reverse/image/index.ts
@@ -1,0 +1,50 @@
+import {
+    type ApplicationCommandInteraction,
+    SlashCommand,
+    SlashCommandOptionBuilder
+} from "@barry/core";
+import { type APIAttachment, MessageFlags } from "@discordjs/core";
+import type GeneralModule from "../../../../index.js";
+
+import { getReverseContent } from "../../../../functions/reverse/getReverseContent.js";
+import config from "../../../../../../config.js";
+
+/**
+ * Represents a slash command for reverse searching an image.
+ */
+export default class extends SlashCommand<GeneralModule> {
+    /**
+     * Represents a slash command for reverse searching an image.
+     *
+     * @param module The module this command belongs to.
+     */
+    constructor(module: GeneralModule) {
+        super(module, {
+            name: "image",
+            description: "Reverse search an image.",
+            options: {
+                image: SlashCommandOptionBuilder.attachments({
+                    description: "The image to reverse search.",
+                    required: true
+                })
+            }
+        });
+    }
+
+    /**
+     * Executes the "/reverse image" command.
+     *
+     * @param interaction The interaction that triggered the command.
+     * @param options The provided image to reverse search.
+     */
+    async execute(interaction: ApplicationCommandInteraction, options: { image: APIAttachment }): Promise<void> {
+        if (!options.image.content_type?.startsWith("image")) {
+            return interaction.createMessage({
+                content: `${config.emotes.error} That is not a valid image.`,
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
+        await interaction.createMessage(getReverseContent([options.image]));
+    }
+}

--- a/apps/barry/src/modules/general/commands/chatinput/reverse/index.ts
+++ b/apps/barry/src/modules/general/commands/chatinput/reverse/index.ts
@@ -1,0 +1,29 @@
+import type GeneralModule from "../../../index.js";
+
+import { SlashCommand } from "@barry/core";
+import ReverseImageCommand from "./image/index.js";
+
+/**
+ * Represents a slash command for reverse searching an image.
+ */
+export default class extends SlashCommand<GeneralModule> {
+    /**
+     * Represents a slash command for reverse searching an image.
+     *
+     * @param module The module this command belongs to.
+     */
+    constructor(module: GeneralModule) {
+        super(module, {
+            name: "reverse",
+            description: "Reverse search an image.",
+            children: [ReverseImageCommand]
+        });
+    }
+
+    /**
+     * Executes the "/reverse" command. Will throw an error if executed.
+     */
+    execute(): Promise<void> {
+        throw new Error("Parent commands cannot be executed.");
+    }
+}

--- a/apps/barry/src/modules/general/commands/message/reverse/index.ts
+++ b/apps/barry/src/modules/general/commands/message/reverse/index.ts
@@ -1,29 +1,38 @@
 import {
-    type APIAttachment,
-    type APIInteractionResponseCallbackData,
-    MessageFlags
-} from "@discordjs/core";
-import {
     type ApplicationCommandInteraction,
     type MessageCommandTarget,
     MessageCommand
 } from "@barry/core";
 
 import type GeneralModule from "../../../index.js";
+
+import { MessageFlags } from "@discordjs/core";
+import { createPaginatedMessage } from "../../../../../utils/pagination.js";
+import { getReverseContent } from "../../../functions/reverse/getReverseContent.js";
+
 import config from "../../../../../config.js";
 
-const GOOGLE_LENS = "https://lens.google.com/uploadbyurl?url=";
-const YANDEX = "https://yandex.com/images/touch/search?rpt=imageview&url=";
-const BING = "https://www.bing.com/images/search?view=detailv2&iss=sbi&form=SBIVSP&sbisrc=UrlPaste&q=imgurl:";
-const TINEYE = "https://www.tineye.com/search/?url=";
-
+/**
+ * Represents a slash command for reverse searching an image.
+ */
 export default class extends MessageCommand<GeneralModule> {
+    /**
+     * Represents a slash command for reverse searching an image.
+     *
+     * @param module The module this command belongs to.
+     */
     constructor(module: GeneralModule) {
         super(module, {
             name: "Reverse Search Image"
         });
     }
 
+    /**
+     * Executes the "Reverse Search Image" command.
+     *
+     * @param interaction The interaction that triggered the command.
+     * @param target The resolved data provided with the command.
+     */
     async execute(interaction: ApplicationCommandInteraction, { message }: MessageCommandTarget): Promise<void> {
         const attachments = message.attachments.filter((a) => a.content_type?.startsWith("image"));
         if (attachments.length === 0) {
@@ -33,26 +42,20 @@ export default class extends MessageCommand<GeneralModule> {
             });
         }
 
-        await interaction.createMessage(this.#getContent(attachments[0]));
-    }
-
-    #getContent(attachment: APIAttachment): APIInteractionResponseCallbackData {
-        const url = encodeURIComponent(attachment.url);
-
-        const google = `[${config.emotes.check} **Google Lens**](${GOOGLE_LENS + url})`;
-        const yandex = `[${config.emotes.check} **Yandex**](${YANDEX + url})`;
-        const bing = `[${config.emotes.check} **Bing**](${BING + url})`;
-        const tinEye = `[${config.emotes.check} **TinEye**](${TINEYE + url})`;
-
-        return {
-            embeds: [{
-                color: config.defaultColor,
-                description: `${google}\n${yandex}\n${bing}\n${tinEye}\n\n**Original image:**`,
-                image: {
-                    url: attachment.url
+        await createPaginatedMessage({
+            buttons: {
+                next: {
+                    label: "Next Image"
+                },
+                previous: {
+                    label: "Previous Image"
                 }
-            }],
-            flags: MessageFlags.Ephemeral
-        };
+            },
+            content: (_, index) => getReverseContent(attachments, index),
+            flags: MessageFlags.Ephemeral,
+            interaction: interaction,
+            pageSize: 1,
+            values: attachments
+        });
     }
 }

--- a/apps/barry/src/modules/general/commands/user/reverse/index.ts
+++ b/apps/barry/src/modules/general/commands/user/reverse/index.ts
@@ -1,0 +1,46 @@
+import {
+    type ApplicationCommandInteraction,
+    type UserCommandTarget,
+    UserCommand
+} from "@barry/core";
+
+import type GeneralModule from "../../../index.js";
+
+import { MessageFlags } from "@discordjs/core";
+import { getReverseAvatarContent } from "../../../functions/reverse/getReverseContent.js";
+
+import config from "../../../../../config.js";
+
+/**
+ * Represents a slash command for reverse searching a user's avatar.
+ */
+export default class extends UserCommand<GeneralModule> {
+    /**
+     * Represents a slash command for reverse searching a user's avatar.
+     *
+     * @param module The module this command belongs to.
+     */
+    constructor(module: GeneralModule) {
+        super(module, {
+            name: "Reverse Search Image"
+        });
+    }
+
+    /**
+     * Executes the "Reverse Search Image" command.
+     *
+     * @param interaction The interaction that triggered the command.
+     * @param target The resolved data provided with the command.
+     */
+    async execute(interaction: ApplicationCommandInteraction, { user }: UserCommandTarget): Promise<void> {
+        if (user.avatar === null) {
+            return interaction.createMessage({
+                content: `${config.emotes.error} This user does not have an avatar.`,
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
+        const avatarURL = this.client.api.rest.cdn.avatar(user.id, user.avatar, { size: 1024 });
+        await interaction.createMessage(getReverseAvatarContent(avatarURL));
+    }
+}

--- a/apps/barry/src/modules/general/functions/reverse/getReverseContent.ts
+++ b/apps/barry/src/modules/general/functions/reverse/getReverseContent.ts
@@ -1,0 +1,86 @@
+import {
+    type APIAttachment,
+    type APIInteractionResponseCallbackData,
+    MessageFlags
+} from "@discordjs/core";
+
+import config from "../../../../config.js";
+
+/**
+ * Base URL for Google Lens search results.
+ */
+const GOOGLE_LENS = "https://lens.google.com/uploadbyurl?url=";
+
+/**
+ * Base URL for Yandex search results.
+ */
+const YANDEX = "https://yandex.com/images/touch/search?rpt=imageview&url=";
+
+/**
+ * Base URL for Bing search results.
+ */
+const BING = "https://www.bing.com/images/search?view=detailv2&iss=sbi&form=SBIVSP&sbisrc=UrlPaste&q=imgurl:";
+
+/**
+ * Returns the content for the reverse search result.
+ *
+ * @param attachments An array of the found attachments.
+ * @param index The index of the selected attachment.
+ * @returns The search results.
+ */
+export function getReverseContent(attachments: APIAttachment[], index: number = 0): APIInteractionResponseCallbackData {
+    const selected = attachments[index];
+    const encodedURL = encodeURIComponent(selected.url);
+
+    const results = `${config.emotes.googleLens} [**Google Lens**](${GOOGLE_LENS + encodedURL})\n`
+        + `${config.emotes.yandex} [**Yandex**](${YANDEX + encodedURL})\n`
+        + `${config.emotes.bing} [**Bing**](${BING + encodedURL})\n`;
+
+    let images = "";
+    if (attachments.length > 1) {
+        images += "### Found Images\n";
+        for (let i = 0; i < attachments.length; i++) {
+            if (i === index) {
+                images += `${i + 1}. **[${attachments[i].filename} (selected)](${attachments[i].url})**\n`;
+            } else {
+                images += `${i + 1}. [${attachments[i].filename}](${attachments[i].url})\n`;
+            }
+        }
+    }
+
+    return {
+        embeds: [{
+            color: config.defaultColor,
+            description: `${results}${images}### Selected Image`,
+            image: {
+                url: selected.url
+            }
+        }],
+        flags: MessageFlags.Ephemeral
+    };
+}
+
+/**
+ * Returns the content for the reverse search result of a user's avatar.
+ *
+ * @param avatarURL The URL of the avatar to reverse search.
+ * @returns The search results.
+ */
+export function getReverseAvatarContent(avatarURL: string): APIInteractionResponseCallbackData {
+    const encodedURL = encodeURIComponent(avatarURL);
+
+    const results = `${config.emotes.googleLens} [**Google Lens**](${GOOGLE_LENS + encodedURL})\n`
+        + `${config.emotes.yandex} [**Yandex**](${YANDEX + encodedURL})\n`
+        + `${config.emotes.bing} [**Bing**](${BING + encodedURL})\n`;
+
+    return {
+        embeds: [{
+            color: config.defaultColor,
+            description: `${results}### Selected Image`,
+            image: {
+                url: avatarURL
+            }
+        }],
+        flags: MessageFlags.Ephemeral
+    };
+}

--- a/apps/barry/src/modules/general/index.ts
+++ b/apps/barry/src/modules/general/index.ts
@@ -1,6 +1,6 @@
 import { type Client, Module, ValidationError } from "@barry/core";
 
-import { loadCommands } from "../../utils.js";
+import { loadCommands } from "../../utils/index.js";
 import config from "../../config.js";
 
 /**

--- a/apps/barry/src/utils/index.ts
+++ b/apps/barry/src/utils/index.ts
@@ -1,0 +1,2 @@
+export * from "./loadFolder.js";
+export * from "./pagination.js";

--- a/apps/barry/src/utils/loadFolder.ts
+++ b/apps/barry/src/utils/loadFolder.ts
@@ -7,9 +7,10 @@ import {
     Module
 } from "@barry/core";
 
-import fs from "node:fs/promises";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+
+import fs from "node:fs/promises";
 
 /**
  * A promise resolving into an array of constructor functions.

--- a/apps/barry/src/utils/pagination.ts
+++ b/apps/barry/src/utils/pagination.ts
@@ -1,0 +1,193 @@
+import type { Awaitable, ReplyableInteraction } from "@barry/core";
+import {
+    type APIActionRowComponent,
+    type APIButtonComponentWithCustomId,
+    type APIInteractionResponseCallbackData,
+    type MessageFlags,
+    ButtonStyle,
+    ComponentType
+} from "@discordjs/core";
+
+import config from "../config.js";
+
+/**
+ * Represents a function that generates the content for a specific page.
+ */
+export type PaginationContent<T> = (values: T[], index: number) => Awaitable<APIInteractionResponseCallbackData>;
+
+/**
+ * Represents the options for customizing the pagination buttons.
+ */
+export interface ButtonOptions {
+    /**
+     * Partial override for the 'Next Page' button.
+     */
+    next?: Partial<APIButtonComponentWithCustomId>;
+
+    /**
+     * Partial override for the 'Previous Page' button.
+     */
+    previous?: Partial<APIButtonComponentWithCustomId>;
+}
+
+/**
+ * Represents the options for the pagination.
+ */
+export interface PaginationOptions<T> {
+    /**
+     * The options for customizing the pagination buttons.
+     */
+    buttons?: ButtonOptions;
+
+    /**
+     * A function that generates the content for a specific page.
+     */
+    content: PaginationContent<T>;
+
+    /**
+     * Optional flags for deferring the interaction.
+     */
+    flags?: MessageFlags;
+
+    /**
+     * The interaction to reply to.
+     */
+    interaction: ReplyableInteraction;
+
+    /**
+     * The amount of items to show per page.
+     */
+    pageSize: number;
+
+    /**
+     * The timeout duration in milliseconds (default: 10 minutes).
+     */
+    timeout?: number;
+
+    /**
+     * An array of items to paginate.
+     */
+    values: T[];
+}
+
+/**
+ * Returns the button components for the pagination.
+ *
+ * @param index The index of the selected page.
+ * @param lastIndex The index of the last page.
+ * @param options Optional options for the buttons.
+ */
+const getComponents = (
+    index: number,
+    lastIndex: number,
+    options: ButtonOptions = {}
+): Array<APIActionRowComponent<APIButtonComponentWithCustomId>> => [{
+    components: [
+        {
+            custom_id: "previous",
+            disabled: index <= 0,
+            emoji: {
+                id: config.emotes.previous.id,
+                name: config.emotes.previous.name
+            },
+            label: "Previous Page",
+            style: ButtonStyle.Secondary,
+            type: ComponentType.Button,
+            ...options.previous
+        },
+        {
+            custom_id: "next",
+            disabled: index >= lastIndex,
+            emoji: {
+                id: config.emotes.next.id,
+                name: config.emotes.next.name
+            },
+            label: "Next Page",
+            style: ButtonStyle.Secondary,
+            type: ComponentType.Button,
+            ...options.next
+        }
+    ],
+    type: ComponentType.ActionRow
+}];
+
+/**
+ * Returns the content for a specific page in the pagination.
+ *
+ * @param index The index of the selected page.
+ * @param options Options for the pagination.
+ */
+async function getPageContent<T>(
+    index: number,
+    options: PaginationOptions<T>
+): Promise<APIInteractionResponseCallbackData> {
+    const chunk = options.values.slice(index * options.pageSize, (index + 1) * options.pageSize);
+    const lastPage = Math.ceil(options.values.length / options.pageSize);
+
+    const content = await options.content(chunk, index);
+    if (options.values.length > options.pageSize) {
+        const components = getComponents(index, lastPage - 1, options.buttons);
+
+        if (content.components !== undefined) {
+            content.components.push(...components);
+        } else {
+            content.components = components;
+        }
+    }
+
+    return content;
+}
+
+/**
+ * Listens for navigation updates.
+ *
+ * @param messageID The ID of the message to listen on.
+ * @param index The index of the selected page.
+ * @param options Options for the pagination.
+ */
+async function awaitNavigationUpdate<T>(
+    messageID: string,
+    index: number,
+    options: PaginationOptions<T>
+): Promise<void> {
+    const response = await options.interaction.awaitMessageComponent(messageID, ["previous", "next"], options.timeout);
+    if (response !== undefined) {
+        index += response.data.customID === "next" ? 1 : -1;
+        options.interaction = response;
+
+        await response.deferUpdate();
+        await handleNavigationUpdate(index, options);
+    } else {
+        await options.interaction.editOriginalMessage({ components: [] });
+    }
+}
+
+/**
+ * Handles the navigation of the pagination.
+ *
+ * @param index The index of the selected page.
+ * @param options Options for the pagination.
+ */
+async function handleNavigationUpdate<T>(
+    index: number,
+    options: PaginationOptions<T>
+): Promise<void> {
+    const content = await getPageContent(index, options);
+    const message = await options.interaction.editOriginalMessage(content);
+
+    if (options.values.length > options.pageSize) {
+        await awaitNavigationUpdate(message.id, index, options);
+    }
+}
+
+/**
+ * Creates a paginated message.
+ *
+ * @param options Options for the pagination.
+ */
+export async function createPaginatedMessage<T>(options: PaginationOptions<T>): Promise<void> {
+    options.timeout ??= 600000;
+
+    await options.interaction.defer({ flags: options.flags });
+    await handleNavigationUpdate(0, options);
+}

--- a/apps/barry/tests/modules/general/commands/chatinput/reverse/image/index.test.ts
+++ b/apps/barry/tests/modules/general/commands/chatinput/reverse/image/index.test.ts
@@ -1,54 +1,47 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-    createMockApplicationCommandInteraction,
-    mockAttachment,
-    mockMessage
-} from "@barry/testing";
+import { createMockApplicationCommandInteraction, mockAttachment } from "@barry/testing";
 
 import { ApplicationCommandInteraction } from "@barry/core";
 import { MessageFlags } from "@discordjs/core";
-import { createMockClient } from "../../../../../mocks/index.js";
+import { createMockClient } from "../../../../../../mocks/index.js";
 
-import GeneralModule from "../../../../../../src/modules/general/index.js";
-import ReverseCommand from "../../../../../../src/modules/general/commands/message/reverse/index.js";
+import GeneralModule from "../../../../../../../src/modules/general/index.js";
+import ReverseImageCommand from "../../../../../../../src/modules/general/commands/chatinput/reverse/image/index.js";
 
 describe("Reverse Search Image", () => {
-    let command: ReverseCommand;
+    let command: ReverseImageCommand;
     let interaction: ApplicationCommandInteraction;
 
     beforeEach(() => {
         const client = createMockClient();
 
         const module = new GeneralModule(client);
-        command = new ReverseCommand(module);
+        command = new ReverseImageCommand(module);
 
         const data = createMockApplicationCommandInteraction();
         interaction = new ApplicationCommandInteraction(data, command.client, vi.fn());
+        interaction.createMessage = vi.fn();
     });
 
-    it("should send an error message if no images are found in the message", async () => {
-        interaction.createMessage = vi.fn();
-
+    it("should send an error message if the provided attachment is not an image", async () => {
         await command.execute(interaction, {
-            message: mockMessage
+            image: { ...mockAttachment, content_type: "text/plain" }
         });
 
         expect(interaction.createMessage).toHaveBeenCalledOnce();
         expect(interaction.createMessage).toHaveBeenCalledWith({
-            content: expect.stringContaining("Could not find any images in this message."),
+            content: expect.stringContaining("That is not a valid image."),
             flags: MessageFlags.Ephemeral
         });
     });
 
-    it("should send the reverse search results if an image is found", async () => {
-        interaction.editOriginalMessage = vi.fn();
-
+    it("should send the reverse search results if a valid image is provided", async () => {
         await command.execute(interaction, {
-            message: { ...mockMessage, attachments: [mockAttachment] }
+            image: mockAttachment
         });
 
-        expect(interaction.editOriginalMessage).toHaveBeenCalledOnce();
-        expect(interaction.editOriginalMessage).toHaveBeenCalledWith({
+        expect(interaction.createMessage).toHaveBeenCalledOnce();
+        expect(interaction.createMessage).toHaveBeenCalledWith({
             embeds: [
                 expect.objectContaining({
                     description: expect.stringContaining("**Google Lens**"),

--- a/apps/barry/tests/modules/general/commands/user/reverse/index.test.ts
+++ b/apps/barry/tests/modules/general/commands/user/reverse/index.test.ts
@@ -1,59 +1,59 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-    createMockApplicationCommandInteraction,
-    mockAttachment,
-    mockMessage
-} from "@barry/testing";
+import { createMockApplicationCommandInteraction, mockUser } from "@barry/testing";
 
 import { ApplicationCommandInteraction } from "@barry/core";
+import { CDN } from "@discordjs/rest";
 import { MessageFlags } from "@discordjs/core";
 import { createMockClient } from "../../../../../mocks/index.js";
 
 import GeneralModule from "../../../../../../src/modules/general/index.js";
-import ReverseCommand from "../../../../../../src/modules/general/commands/message/reverse/index.js";
+import ReverseCommand from "../../../../../../src/modules/general/commands/user/reverse/index.js";
 
 describe("Reverse Search Image", () => {
     let command: ReverseCommand;
     let interaction: ApplicationCommandInteraction;
 
     beforeEach(() => {
-        const client = createMockClient();
+        const client = createMockClient({
+            api: {
+                rest: {
+                    cdn: new CDN()
+                }
+            }
+        });
 
         const module = new GeneralModule(client);
         command = new ReverseCommand(module);
 
         const data = createMockApplicationCommandInteraction();
         interaction = new ApplicationCommandInteraction(data, command.client, vi.fn());
+        interaction.createMessage = vi.fn();
     });
 
-    it("should send an error message if no images are found in the message", async () => {
-        interaction.createMessage = vi.fn();
-
+    it("should send an error message if the user has no avatar", async () => {
         await command.execute(interaction, {
-            message: mockMessage
+            user: { ...mockUser, avatar: null }
         });
 
         expect(interaction.createMessage).toHaveBeenCalledOnce();
         expect(interaction.createMessage).toHaveBeenCalledWith({
-            content: expect.stringContaining("Could not find any images in this message."),
+            content: expect.stringContaining("This user does not have an avatar."),
             flags: MessageFlags.Ephemeral
         });
     });
 
-    it("should send the reverse search results if an image is found", async () => {
-        interaction.editOriginalMessage = vi.fn();
-
+    it("should send the reverse search results if the user does have an avatar", async () => {
         await command.execute(interaction, {
-            message: { ...mockMessage, attachments: [mockAttachment] }
+            user: mockUser
         });
 
-        expect(interaction.editOriginalMessage).toHaveBeenCalledOnce();
-        expect(interaction.editOriginalMessage).toHaveBeenCalledWith({
+        expect(interaction.createMessage).toHaveBeenCalledOnce();
+        expect(interaction.createMessage).toHaveBeenCalledWith({
             embeds: [
                 expect.objectContaining({
                     description: expect.stringContaining("**Google Lens**"),
                     image: {
-                        url: mockAttachment.url
+                        url: `https://cdn.discordapp.com/avatars/${mockUser.id}/${mockUser.avatar}.webp?size=1024`
                     }
                 })
             ],

--- a/apps/barry/tests/modules/general/functions/reverse/getReverseContent.test.ts
+++ b/apps/barry/tests/modules/general/functions/reverse/getReverseContent.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { MessageFlags } from "@discordjs/core";
+import { getReverseContent } from "../../../../../src/modules/general/functions/reverse/getReverseContent.js";
+import { mockAttachment } from "@barry/testing";
+
+import config from "../../../../../src/config.js";
+
+describe("getReverseContent", () => {
+    it("should return the correct content for a single attachment", () => {
+        const content = getReverseContent([mockAttachment]);
+
+        expect(content).toEqual({
+            embeds: [{
+                color: expect.any(Number),
+                description: `${config.emotes.googleLens} [**Google Lens**](https://lens.google.com/uploadbyurl?url=${encodeURIComponent(mockAttachment.url)})\n`
+                    + `${config.emotes.yandex} [**Yandex**](https://yandex.com/images/touch/search?rpt=imageview&url=${encodeURIComponent(mockAttachment.url)})\n`
+                    + `${config.emotes.bing} [**Bing**](https://www.bing.com/images/search?view=detailv2&iss=sbi&form=SBIVSP&sbisrc=UrlPaste&q=imgurl:${encodeURIComponent(mockAttachment.url)})\n`
+                    + "### Selected Image",
+                image: {
+                    url: mockAttachment.url
+                }
+            }],
+            flags: expect.any(Number)
+        });
+    });
+
+    it("should return the correct content for multiple attachments", () => {
+        const content = getReverseContent([mockAttachment, mockAttachment, mockAttachment], 1);
+
+        expect(content).toEqual({
+            embeds: [{
+                color: expect.any(Number),
+                description: `${config.emotes.googleLens} [**Google Lens**](https://lens.google.com/uploadbyurl?url=${encodeURIComponent(mockAttachment.url)})\n`
+                    + `${config.emotes.yandex} [**Yandex**](https://yandex.com/images/touch/search?rpt=imageview&url=${encodeURIComponent(mockAttachment.url)})\n`
+                    + `${config.emotes.bing} [**Bing**](https://www.bing.com/images/search?view=detailv2&iss=sbi&form=SBIVSP&sbisrc=UrlPaste&q=imgurl:${encodeURIComponent(mockAttachment.url)})\n`
+                    + "### Found Images\n"
+                    + `1. [${mockAttachment.filename}](${mockAttachment.url})\n`
+                    + `2. **[${mockAttachment.filename} (selected)](${mockAttachment.url})**\n`
+                    + `3. [${mockAttachment.filename}](${mockAttachment.url})\n`
+                    + "### Selected Image",
+                image: {
+                    url: mockAttachment.url
+                }
+            }],
+            flags: MessageFlags.Ephemeral
+        });
+    });
+});

--- a/apps/barry/tests/utils/loadFolder.test.ts
+++ b/apps/barry/tests/utils/loadFolder.test.ts
@@ -1,7 +1,7 @@
 import type { Dirent } from "node:fs";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { loadCommands, loadEvents, loadFolder, loadModules } from "../src/utils.js";
+import { loadCommands, loadEvents, loadFolder, loadModules } from "../../src/utils/index.js";
 import { BaseCommand, Event, Module, SlashCommand } from "@barry/core";
 
 import fs from "node:fs/promises";
@@ -25,7 +25,7 @@ class MockModule extends Module {}
 
 vi.mock("node:fs/promises");
 
-describe("utils", () => {
+describe("loadFolder", () => {
     function createMockFile(name: string): Dirent {
         return {
             isDirectory: vi.fn().mockReturnValue(false),

--- a/apps/barry/tests/utils/pagination.test.ts
+++ b/apps/barry/tests/utils/pagination.test.ts
@@ -1,0 +1,259 @@
+import {
+    type Client,
+    type ReplyableInteraction,
+    ApplicationCommandInteraction,
+    MessageComponentInteraction
+} from "@barry/core";
+import { type PaginationOptions, createPaginatedMessage } from "../../src/utils/index.js";
+
+import { ButtonStyle, ComponentType, MessageFlags } from "@discordjs/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    createMockApplicationCommandInteraction,
+    createMockMessageComponentInteraction,
+    mockMessage
+} from "@barry/testing";
+
+import { createMockClient } from "../mocks/index.js";
+
+describe("createPaginatedMessage", () => {
+    let client: Client;
+    let mockPaginationOptions: PaginationOptions<string>;
+
+    let interaction: ReplyableInteraction;
+    let nextInteraction: MessageComponentInteraction;
+    let previousInteraction: MessageComponentInteraction;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+
+        client = createMockClient({
+            api: {
+                webhooks: {
+                    editMessage: vi.fn().mockResolvedValue(mockMessage)
+                }
+            }
+        });
+
+        const data = createMockApplicationCommandInteraction();
+        const nextComponent = createMockMessageComponentInteraction({
+            component_type: ComponentType.Button,
+            custom_id: "next"
+        });
+        const previousComponent = createMockMessageComponentInteraction({
+            component_type: ComponentType.Button,
+            custom_id: "previous"
+        });
+
+        interaction = new ApplicationCommandInteraction(data, client, vi.fn());
+        nextInteraction = new MessageComponentInteraction(nextComponent, client, vi.fn());
+        previousInteraction = new MessageComponentInteraction(previousComponent, client, vi.fn());
+
+        nextInteraction.deferUpdate = vi.fn();
+        previousInteraction.deferUpdate = vi.fn();
+
+        mockPaginationOptions = {
+            content: ([value]) => ({ content: value }),
+            flags: MessageFlags.Ephemeral,
+            interaction: interaction,
+            pageSize: 1,
+            values: ["Foo", "Bar", "Baz"]
+        };
+    });
+
+    it("should defer the interaction with provided flags", async () => {
+        const deferSpy = vi.spyOn(interaction, "defer");
+        const promise = createPaginatedMessage(mockPaginationOptions);
+
+        await vi.runAllTimersAsync();
+        await promise;
+
+        expect(deferSpy).toHaveBeenCalledOnce();
+        expect(deferSpy).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    });
+
+    it("should start on page one initially", async () => {
+        const editSpy = vi.spyOn(interaction, "editOriginalMessage");
+        const promise = createPaginatedMessage(mockPaginationOptions);
+
+        await vi.runAllTimersAsync();
+        await promise;
+
+        expect(editSpy).toHaveBeenCalledTimes(2);
+        expect(editSpy).toHaveBeenCalledWith({
+            components: expect.any(Array),
+            content: "Foo"
+        });
+    });
+
+    it("should navigate through pages when a message component interaction is received", async () => {
+        const initialEditSpy = vi.spyOn(interaction, "editOriginalMessage");
+        vi.spyOn(interaction, "awaitMessageComponent")
+            .mockResolvedValueOnce(nextInteraction);
+
+        const nextEditSpy = vi.spyOn(nextInteraction, "editOriginalMessage");
+        vi.spyOn(nextInteraction, "awaitMessageComponent")
+            .mockResolvedValueOnce(nextInteraction)
+            .mockResolvedValueOnce(previousInteraction);
+
+        const previousEditSpy = vi.spyOn(previousInteraction, "editOriginalMessage");
+        vi.spyOn(previousInteraction, "awaitMessageComponent")
+            .mockResolvedValue(undefined);
+
+        await createPaginatedMessage(mockPaginationOptions);
+
+        expect(initialEditSpy).toHaveBeenCalledOnce();
+        expect(initialEditSpy).toHaveBeenCalledWith({
+            components: expect.any(Array),
+            content: "Foo"
+        });
+
+        expect(nextEditSpy).toHaveBeenCalledTimes(2);
+        expect(nextEditSpy).toHaveBeenCalledWith({
+            components: expect.any(Array),
+            content: "Bar"
+        });
+        expect(nextEditSpy).toHaveBeenLastCalledWith({
+            components: expect.any(Array),
+            content: "Baz"
+        });
+
+        expect(previousEditSpy).toHaveBeenCalledTimes(2);
+        expect(previousEditSpy).toHaveBeenCalledWith({
+            components: expect.any(Array),
+            content: "Bar"
+        });
+    });
+
+    it("should remove the navigation buttons when the timeout has expired", async () => {
+        const editSpy = vi.spyOn(interaction, "editOriginalMessage");
+        const promise = createPaginatedMessage(mockPaginationOptions);
+
+        await vi.runAllTimersAsync();
+        await promise;
+
+        expect(editSpy).toHaveBeenCalledTimes(2);
+        expect(editSpy).toHaveBeenLastCalledWith({
+            components: []
+        });
+    });
+
+    it("should disable the 'Previous Page' button on the first page", async () => {
+        const editSpy = vi.spyOn(interaction, "editOriginalMessage");
+        const promise = createPaginatedMessage(mockPaginationOptions);
+
+        await vi.runAllTimersAsync();
+        await promise;
+
+        expect(editSpy).toHaveBeenCalledTimes(2);
+        expect(editSpy).toHaveBeenCalledWith({
+            components: [{
+                components: [
+                    expect.objectContaining({ custom_id: "previous", disabled: true }),
+                    expect.objectContaining({ custom_id: "next" })
+                ],
+                type: ComponentType.ActionRow
+            }],
+            content: "Foo"
+        });
+    });
+
+    it("should disable the 'Next Page' button on the last page", async () => {
+        const editSpy = vi.spyOn(nextInteraction, "editOriginalMessage");
+
+        vi.spyOn(interaction, "awaitMessageComponent")
+            .mockResolvedValueOnce(nextInteraction);
+
+        vi.spyOn(nextInteraction, "awaitMessageComponent")
+            .mockResolvedValueOnce(nextInteraction)
+            .mockResolvedValue(undefined);
+
+        await createPaginatedMessage(mockPaginationOptions);
+
+        expect(editSpy).toHaveBeenCalledTimes(3);
+        expect(editSpy).toHaveBeenCalledWith({
+            components: [{
+                components: [
+                    expect.objectContaining({ custom_id: "previous" }),
+                    expect.objectContaining({ custom_id: "next", disabled: true })
+                ],
+                type: ComponentType.ActionRow
+            }],
+            content: "Baz"
+        });
+    });
+
+    it("should not override existing components", async () => {
+        const editSpy = vi.spyOn(interaction, "editOriginalMessage");
+        const promise = createPaginatedMessage({
+            ...mockPaginationOptions,
+            content: ([value]) => ({
+                components: [{
+                    components: [],
+                    type: ComponentType.ActionRow
+                }],
+                content: value
+            })
+        });
+
+        await vi.runAllTimersAsync();
+        await promise;
+
+        expect(editSpy).toHaveBeenCalledTimes(2);
+        expect(editSpy).toHaveBeenCalledWith({
+            components: [
+                {
+                    components: [],
+                    type: ComponentType.ActionRow
+                },
+                {
+                    components: [
+                        expect.objectContaining({ custom_id: "previous" }),
+                        expect.objectContaining({ custom_id: "next" })
+                    ],
+                    type: ComponentType.ActionRow
+                }
+            ],
+            content: "Foo"
+        });
+    });
+
+    it("should override the navigation buttons if the 'buttons' option is provided", async () => {
+        const editSpy = vi.spyOn(interaction, "editOriginalMessage");
+        const promise = createPaginatedMessage({
+            ...mockPaginationOptions,
+            buttons: {
+                next: {
+                    label: ">"
+                },
+                previous: {
+                    label: "<",
+                    style: ButtonStyle.Danger
+                }
+            }
+        });
+
+        await vi.runAllTimersAsync();
+        await promise;
+
+        expect(editSpy).toHaveBeenCalledTimes(2);
+        expect(editSpy).toHaveBeenCalledWith({
+            components: [{
+                components: [
+                    expect.objectContaining({
+                        custom_id: "previous",
+                        label: "<",
+                        style: ButtonStyle.Danger
+                    }),
+                    expect.objectContaining({
+                        custom_id: "next",
+                        label: ">",
+                        style: ButtonStyle.Secondary
+                    })
+                ],
+                type: ComponentType.ActionRow
+            }],
+            content: "Foo"
+        });
+    });
+});


### PR DESCRIPTION
- Adds a `Reverse Image Search` user command.
- Adds a `/reverse image` slash command.
- Adds pagination (used for the message command).
- Updates the `Reverse Image Search` message command.