### PR TITLE
feat(ReplyableInteraction)!: add userID option to awaitMessageComponent

### DIFF
--- a/apps/barry/src/utils/pagination.ts
+++ b/apps/barry/src/utils/pagination.ts
@@ -145,12 +145,12 @@ async function getPageContent<T>(
  * @param index The index of the selected page.
  * @param options Options for the pagination.
  */
-async function awaitNavigationUpdate<T>(
-    messageID: string,
-    index: number,
-    options: PaginationOptions<T>
-): Promise<void> {
-    const response = await options.interaction.awaitMessageComponent(messageID, ["previous", "next"], options.timeout);
+async function awaitNavigationUpdate<T>(index: number, options: PaginationOptions<T>): Promise<void> {
+    const response = await options.interaction.awaitMessageComponent({
+        customIDs: ["previous", "next"],
+        timeout: options.timeout
+    });
+
     if (response !== undefined) {
         index += response.data.customID === "next" ? 1 : -1;
         options.interaction = response;
@@ -168,15 +168,12 @@ async function awaitNavigationUpdate<T>(
  * @param index The index of the selected page.
  * @param options Options for the pagination.
  */
-async function handleNavigationUpdate<T>(
-    index: number,
-    options: PaginationOptions<T>
-): Promise<void> {
+async function handleNavigationUpdate<T>(index: number, options: PaginationOptions<T>): Promise<void> {
     const content = await getPageContent(index, options);
-    const message = await options.interaction.editOriginalMessage(content);
+    await options.interaction.editOriginalMessage(content);
 
     if (options.values.length > options.pageSize) {
-        await awaitNavigationUpdate(message.id, index, options);
+        await awaitNavigationUpdate(index, options);
     }
 }
 

--- a/packages/core/src/interactions/ReplyableInteraction.ts
+++ b/packages/core/src/interactions/ReplyableInteraction.ts
@@ -30,6 +30,31 @@ interface APIInteractionResponseCallbackDataWithFiles extends APIInteractionResp
 }
 
 /**
+ * Represents options for awaiting a message component response.
+ */
+interface AwaitMessageComponentOptions {
+    /**
+     * An array of `custom_id`'s to match.
+     */
+    customIDs?: string[];
+
+    /**
+     * The ID of the message to match. Defaults to the initial response.
+     */
+    messageID?: string;
+
+    /**
+     * The timeout duration in milliseconds. Defaults to 15 minutes.
+     */
+    timeout?: number;
+
+    /**
+     * The ID of the user to match, or null to allow any user. Defaults to the interaction user.
+     */
+    userID?: string | null;
+}
+
+/**
  * Represents an interaction.
  */
 export class ReplyableInteraction extends Interaction {
@@ -37,6 +62,16 @@ export class ReplyableInteraction extends Interaction {
      * The client that received the interaction.
      */
     #client: Client;
+
+    /**
+     * Whether this interaction has sent its initial interaction response.
+     */
+    #hasInitialResponse: boolean = false;
+
+    /**
+     * The ID of the initial interaction response.
+     */
+    #originalMessageID?: string;
 
     /**
      * Represents an interaction.
@@ -51,34 +86,56 @@ export class ReplyableInteraction extends Interaction {
     }
 
     /**
-     * Waits for a message component response with the specified message and custom ID.
+     * Waits for a message component response.
      *
-     * @param messageID The ID of the message to listen for.
-     * @param customIDs An array of custom IDs to match.
-     * @param timeout The timeout duration in milliseconds (default: 15 minutes).
+     * @param options The options for awaiting the message component response.
      * @returns The matching MessageComponentInteraction or undefined if timed out.
      */
     async awaitMessageComponent(
-        messageID: string,
-        customIDs: string[],
-        timeout: number = 15 * 60 * 1000
+        options: AwaitMessageComponentOptions = {}
     ): Promise<MessageComponentInteraction | void> {
-        return new Promise<MessageComponentInteraction | void>((resolve) => {
-            const listener = (interaction: AnyInteraction): void => {
+        options.customIDs ??= [];
+        options.messageID ??= this.#originalMessageID;
+        options.timeout ??= 15 * 60 * 1000;
+
+        if (options.userID === undefined) {
+            options.userID = this.user.id;
+        }
+
+        if (options.messageID === undefined && !this.#hasInitialResponse) {
+            throw new Error("You must send an initial response before listening for components.");
+        }
+
+        return new Promise((resolve) => {
+            const listener = async (interaction: AnyInteraction): Promise<void> => {
                 if (!interaction.isMessageComponent()) {
                     return;
                 }
 
-                if (interaction.message.id === messageID && customIDs.includes(interaction.data.customID)) {
+                if (options.customIDs?.length && !options.customIDs.includes(interaction.data.customID)) {
+                    return;
+                }
+
+                if (options.userID !== null && interaction.user.id !== options.userID) {
+                    return;
+                }
+
+                if (options.messageID === undefined) {
+                    const message = await this.getOriginalMessage();
+                    options.messageID = message.id;
+                }
+
+                if (interaction.message.id === options.messageID) {
                     this.#client.off(GatewayDispatchEvents.InteractionCreate, listener);
+                    clearTimeout(timeout);
                     resolve(interaction);
                 }
             };
 
-            setTimeout(() => {
+            const timeout = setTimeout(() => {
                 this.#client.off(GatewayDispatchEvents.InteractionCreate, listener);
                 resolve();
-            }, timeout);
+            }, options.timeout);
 
             this.#client.on(GatewayDispatchEvents.InteractionCreate, listener);
         });
@@ -95,7 +152,7 @@ export class ReplyableInteraction extends Interaction {
         customID: string,
         timeout: number = 15 * 60 * 1000
     ): Promise<ModalSubmitInteraction | void> {
-        return new Promise<ModalSubmitInteraction | void>((resolve) => {
+        return new Promise((resolve) => {
             const listener = (interaction: AnyInteraction): void => {
                 if (!interaction.isModalSubmit()) {
                     return;
@@ -146,6 +203,7 @@ export class ReplyableInteraction extends Interaction {
         });
 
         this.acknowledged = true;
+        this.#hasInitialResponse = true;
     }
 
     /**
@@ -186,6 +244,7 @@ export class ReplyableInteraction extends Interaction {
         });
 
         this.acknowledged = true;
+        this.#hasInitialResponse = true;
     }
 
     /**
@@ -244,6 +303,11 @@ export class ReplyableInteraction extends Interaction {
      * @returns The found message.
      */
     async getOriginalMessage(): Promise<APIMessage> {
-        return this.getFollowupMessage("@original");
+        const message = await this.getFollowupMessage("@original");
+
+        this.#hasInitialResponse = true;
+        this.#originalMessageID = message.id;
+
+        return message;
     }
 }

--- a/packages/core/tests/interactions/ReplyableInteraction.test.ts
+++ b/packages/core/tests/interactions/ReplyableInteraction.test.ts
@@ -215,7 +215,7 @@ describe("ReplyableInteraction", () => {
                 const promise = interaction.awaitMessageComponent({
                     customIDs: ["button"],
                     messageID: "91256340920236565",
-                    userID: null
+                    userID: undefined
                 });
 
                 client.emit(GatewayDispatchEvents.InteractionCreate, response);


### PR DESCRIPTION
- **BREAKING CHANGE:** awaitMessageComponent now asks for an options object.
- Adds `userID` option.
- `messageID` now defaults to initial response's message ID.
- `userID` defaults to the interaction's user ID.
- `customIDs` will now allow any component if empty.