### PR TITLE
feat!: allow disabling modules

### DIFF
--- a/apps/barry/src/modules/general/index.ts
+++ b/apps/barry/src/modules/general/index.ts
@@ -1,6 +1,7 @@
 import type { Application } from "../../Application.js";
 
 import { Module, ValidationError } from "@barry/core";
+import { MessageFlags } from "@discordjs/core";
 import { loadCommands } from "../../utils/index.js";
 import config from "../../config.js";
 
@@ -49,12 +50,22 @@ export default class GeneralModule extends Module<Application> {
             } catch (error: unknown) {
                 if (interaction.isApplicationCommand() && error instanceof ValidationError) {
                     return interaction.createMessage({
-                        content: `${config.emotes.error} ${error.message}`
+                        content: `${config.emotes.error} ${error.message}`,
+                        flags: MessageFlags.Ephemeral
                     });
                 }
 
                 this.client.logger.error(error);
             }
         });
+    }
+
+    /**
+     * Checks if the guild has enabled this module.
+     *
+     * @returns Whether the guild has enabled this module.
+     */
+    isEnabled(): boolean {
+        return true;
     }
 }

--- a/apps/barry/src/modules/leveling/events/messageCreate.ts
+++ b/apps/barry/src/modules/leveling/events/messageCreate.ts
@@ -78,7 +78,8 @@ export default class extends Event<LevelingModule> {
      */
     async #isBlacklisted(message: GuildMessageCreateDispatchData): Promise<boolean> {
         const settings = await this.module.levelingSettings.getOrCreate(message.guild_id);
-        return settings.ignoredChannels.includes(message.channel_id)
+        return !settings.enabled
+            || settings.ignoredChannels.includes(message.channel_id)
             || settings.ignoredRoles.some((id) => message.member?.roles.includes(id));
     }
 

--- a/apps/barry/src/modules/leveling/events/voiceStateUpdate.ts
+++ b/apps/barry/src/modules/leveling/events/voiceStateUpdate.ts
@@ -57,12 +57,9 @@ export default class extends Event<LevelingModule> {
      */
     async #isBlacklisted(state: GuildGatewayVoiceState, channelID?: string): Promise<boolean> {
         const settings = await this.module.levelingSettings.getOrCreate(state.guild_id);
-        if (channelID !== undefined && settings.ignoredChannels.includes(channelID)) {
-            return true;
-        }
-
-        return state.member !== undefined
-            && settings.ignoredRoles.some((id) => state.member?.roles.includes(id));
+        return !settings.enabled
+            || (channelID !== undefined && settings.ignoredChannels.includes(channelID))
+            || (state.member !== undefined && settings.ignoredRoles.some((id) => state.member?.roles.includes(id)));
     }
 
     /**

--- a/apps/barry/src/modules/leveling/index.ts
+++ b/apps/barry/src/modules/leveling/index.ts
@@ -118,6 +118,17 @@ export default class LevelingModule extends Module<Application> {
     }
 
     /**
+     * Checks if the guild has enabled this module.
+     *
+     * @param guildID The ID of the guild.
+     * @returns Whether the guild has enabled this module.
+     */
+    async isEnabled(guildID: string): Promise<boolean> {
+        const settings = await this.levelingSettings.getOrCreate(guildID);
+        return settings.enabled;
+    }
+
+    /**
      * Notifies the user about their new level.
      *
      * @param member The member activity record of the user.

--- a/apps/barry/tests/modules/general/index.test.ts
+++ b/apps/barry/tests/modules/general/index.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ApplicationCommandInteraction, Module } from "@barry/core";
+import { MessageFlags } from "@discordjs/core";
 import { createMockApplicationCommandInteraction } from "@barry/testing";
 import { createMockApplication } from "../../mocks/application.js";
 
@@ -70,7 +71,8 @@ describe("GeneralModule", () => {
 
                     expect(interaction.createMessage).toHaveBeenCalledOnce();
                     expect(interaction.createMessage).toHaveBeenCalledWith({
-                        content: expect.stringContaining("You are not permitted to use that command.")
+                        content: expect.stringContaining("You are not permitted to use that command."),
+                        flags: MessageFlags.Ephemeral
                     });
                 });
 
@@ -84,7 +86,8 @@ describe("GeneralModule", () => {
 
                     expect(interaction.createMessage).toHaveBeenCalledOnce();
                     expect(interaction.createMessage).toHaveBeenCalledWith({
-                        content: expect.stringContaining("You are not permitted to use that command.")
+                        content: expect.stringContaining("You are not permitted to use that command."),
+                        flags: MessageFlags.Ephemeral
                     });
                 });
 
@@ -95,7 +98,8 @@ describe("GeneralModule", () => {
                     await module.client.interactions.handle(interaction);
 
                     expect(interaction.createMessage).not.toHaveBeenCalledWith({
-                        content: expect.stringContaining("You are not permitted to use that command.")
+                        content: expect.stringContaining("You are not permitted to use that command."),
+                        flags: MessageFlags.Ephemeral
                     });
                 });
 

--- a/apps/barry/tests/modules/leveling/index.test.ts
+++ b/apps/barry/tests/modules/leveling/index.test.ts
@@ -129,6 +129,38 @@ describe("LevelingModule", () => {
         });
     });
 
+    describe("isEnabled", () => {
+        it("should return true if the guild has the module enabled", async () => {
+            const settingsSpy = vi.spyOn(module.levelingSettings, "getOrCreate").mockResolvedValue({
+                guildID: "68239102456844360",
+                enabled: true,
+                ignoredChannels: [],
+                ignoredRoles: []
+            });
+
+            const enabled = await module.isEnabled("68239102456844360");
+
+            expect(settingsSpy).toHaveBeenCalledOnce();
+            expect(settingsSpy).toHaveBeenCalledWith("68239102456844360");
+            expect(enabled).toBe(true);
+        });
+
+        it("should return false if the guild has the module disabled", async () => {
+            const settingsSpy = vi.spyOn(module.levelingSettings, "getOrCreate").mockResolvedValue({
+                guildID: "68239102456844360",
+                enabled: false,
+                ignoredChannels: [],
+                ignoredRoles: []
+            });
+
+            const enabled = await module.isEnabled("68239102456844360");
+
+            expect(settingsSpy).toHaveBeenCalledOnce();
+            expect(settingsSpy).toHaveBeenCalledWith("68239102456844360");
+            expect(enabled).toBe(false);
+        });
+    });
+
     describe("#notifyMember", () => {
         it("should send a notification in the configured channel if the notification type is 'CustomChannel'", async () => {
             module.memberActivity.upsert = vi.fn();

--- a/packages/core/src/modules/Module.ts
+++ b/packages/core/src/modules/Module.ts
@@ -197,4 +197,12 @@ export abstract class Module<T extends Client = Client> {
             this.events.push(new EventClass(this));
         }
     }
+
+    /**
+     * Checks if the guild has enabled this module.
+     *
+     * @param guildID The ID of the guild.
+     * @returns Whether the guild has enabled this module.
+     */
+    abstract isEnabled(guildID: string): Awaitable<boolean>;
 }

--- a/packages/core/src/services/interactions/ApplicationCommandInteractionHandler.ts
+++ b/packages/core/src/services/interactions/ApplicationCommandInteractionHandler.ts
@@ -46,6 +46,11 @@ export class ApplicationCommandInteractionHandler implements InteractionHandler 
         }
 
         if (interaction.guildID !== undefined) {
+            const moduleEnabled = await command.module.isEnabled(interaction.guildID);
+            if (!moduleEnabled) {
+                throw new ValidationError("This command is currently disabled for this guild.");
+            }
+
             if (command.appPermissions !== undefined && interaction.appPermissions !== undefined) {
                 const perms = interaction.appPermissions & command.appPermissions;
                 if (perms !== command.appPermissions) {

--- a/packages/core/src/services/interactions/AutocompleteInteractionHandler.ts
+++ b/packages/core/src/services/interactions/AutocompleteInteractionHandler.ts
@@ -47,6 +47,13 @@ export class AutocompleteInteractionHandler implements InteractionHandler {
             throw new Error("Application command option is missing autocomplete callback.");
         }
 
+        if (interaction.guildID !== undefined) {
+            const moduleEnabled = await command.module.isEnabled(interaction.guildID);
+            if (!moduleEnabled) {
+                return;
+            }
+        }
+
         if (
             data.type === ApplicationCommandOptionType.Integer ||
             data.type === ApplicationCommandOptionType.Number

--- a/packages/core/tests/mocks/module.ts
+++ b/packages/core/tests/mocks/module.ts
@@ -16,6 +16,10 @@ export function createMockModule(options: ModuleOptions): ConcreteConstructor<Mo
         constructor(client: Client) {
             super(client, options);
         }
+
+        isEnabled(): boolean {
+            return true;
+        }
     };
 }
 
@@ -34,5 +38,9 @@ export class MockModule extends Module {
             ...mockModuleOptions,
             ...options
         });
+    }
+
+    isEnabled(): boolean {
+        return true;
     }
 }

--- a/packages/core/tests/services/interactions/ApplicationCommandInteractionHandler.test.ts
+++ b/packages/core/tests/services/interactions/ApplicationCommandInteractionHandler.test.ts
@@ -143,6 +143,18 @@ describe("ApplicationCommandInteractionHandler", () => {
                 expect(expiresAt).toBeGreaterThan(Date.now());
             });
 
+            it("should throw a ValidationError if the module is disabled", async () => {
+                const data = createMockApplicationCommandInteraction();
+                const interaction = new ApplicationCommandInteraction(data, client);
+                const module = client.modules.get("mock")!;
+
+                vi.spyOn(module, "isEnabled").mockReturnValue(false);
+
+                await expect(() => handler.handle(interaction)).rejects.toThrowError(
+                    "This command is currently disabled for this guild."
+                );
+            });
+
             it("should throw a ValidationError for insufficient bot permissions", async () => {
                 const data = createMockApplicationCommandInteraction();
                 const interaction = new ApplicationCommandInteraction(data, client);

--- a/packages/core/tests/services/interactions/AutocompleteInteractionHandler.test.ts
+++ b/packages/core/tests/services/interactions/AutocompleteInteractionHandler.test.ts
@@ -158,6 +158,19 @@ describe("AutocompleteInteractionHandler", () => {
             });
         });
 
+        it("should do nothing if the module is disabled", async () => {
+            const data = createMockAutocompleteInteraction();
+            const interaction = new AutocompleteInteraction(data, client, vi.fn());
+            const resultSpy = vi.spyOn(interaction, "result");
+            const module = client.modules.get("mock")!;
+
+            vi.spyOn(module, "isEnabled").mockReturnValue(false);
+
+            await handler.handle(interaction);
+
+            expect(resultSpy).not.toHaveBeenCalled();
+        });
+
         describe("Focused option", () => {
             function createMockInteractionWithOption(
                 type: ApplicationCommandOptionType.Integer | ApplicationCommandOptionType.Number,


### PR DESCRIPTION
Adds the possibility within the core to disable a module easily. All command-related interactions will automatically be disabled when a guild disabled it, events will require manual handling.