### PR TITLE
feat(leveling): add rep command

### DIFF
--- a/apps/barry/src/modules/leveling/commands/user/rep/index.ts
+++ b/apps/barry/src/modules/leveling/commands/user/rep/index.ts
@@ -9,24 +9,24 @@ import { MessageFlags } from "@discordjs/core";
 import config from "../../../../../config.js";
 
 /**
- * Represents a user command to add reputation to a member.
+ * Represents a user command to give reputation to a member.
  */
 export default class extends UserCommand<LevelingModule> {
     /**
-     * Represents a user command to add reputation to a member.
+     * Represents a user command to give reputation to a member.
      *
      * @param module The module this command belongs to.
      */
     constructor(module: LevelingModule) {
         super(module, {
-            name: "Add Reputation",
+            name: "Give Reputation",
             cooldown: 86400,
             guildOnly: true
         });
     }
 
     /**
-     * Executes the "Add Reputation" command.
+     * Executes the "Give Reputation" command.
      *
      * @param interaction The interaction that triggered the command.
      * @param target The resolved data provided with the command.

--- a/apps/barry/src/modules/leveling/commands/user/rep/index.ts
+++ b/apps/barry/src/modules/leveling/commands/user/rep/index.ts
@@ -1,0 +1,76 @@
+import {
+    type ApplicationCommandInteraction,
+    type UserCommandTarget,
+    UserCommand
+} from "@barry/core";
+import type LevelingModule from "../../../index.js";
+
+import { MessageFlags } from "@discordjs/core";
+import config from "../../../../../config.js";
+
+/**
+ * Represents a user command to add reputation to a member.
+ */
+export default class extends UserCommand<LevelingModule> {
+    /**
+     * Represents a user command to add reputation to a member.
+     *
+     * @param module The module this command belongs to.
+     */
+    constructor(module: LevelingModule) {
+        super(module, {
+            name: "Add Reputation",
+            cooldown: 86400,
+            guildOnly: true
+        });
+    }
+
+    /**
+     * Executes the "Add Reputation" command.
+     *
+     * @param interaction The interaction that triggered the command.
+     * @param target The resolved data provided with the command.
+     */
+    async execute(interaction: ApplicationCommandInteraction, target: Required<UserCommandTarget>): Promise<void> {
+        if (!interaction.isInvokedInGuild()) {
+            return;
+        }
+
+        if (target.user.id === interaction.user.id) {
+            return interaction.createMessage({
+                content: `${config.emotes.error} You cannot give yourself reputation.`,
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
+        if (target.user.bot) {
+            return interaction.createMessage({
+                content: `${config.emotes.error} You cannot give reputation to a bot.`,
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
+        const settings = await this.module.levelingSettings.getOrCreate(interaction.guildID);
+        if (settings.ignoredRoles.some((id) => interaction.member.roles.includes(id))) {
+            return interaction.createMessage({
+                content: `${config.emotes.error} You are not allowed to use this command.`,
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
+        if (settings.ignoredRoles.some((id) => target.member.roles.includes(id))) {
+            return interaction.createMessage({
+                content: `${config.emotes.error} This user cannot receive reputation.`,
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
+        await this.module.memberActivity.increment(interaction.guildID, target.user.id, {
+            reputation: 1
+        });
+
+        await interaction.createMessage({
+            content: `${config.emotes.check} Gave +1 rep to <@${target.user.id}>.`
+        });
+    }
+}

--- a/apps/barry/tests/modules/leveling/commands/user/rep/index.test.ts
+++ b/apps/barry/tests/modules/leveling/commands/user/rep/index.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockApplicationCommandInteraction, mockInteractionMember, mockUser } from "@barry/testing";
+
+import { ApplicationCommandInteraction } from "@barry/core";
+import { createMockApplication } from "../../../../../mocks/application.js";
+
+import LevelingModule from "../../../../../../src/modules/leveling/index.js";
+import ReputationCommand from "../../../../../../src/modules/leveling/commands/user/rep/index.js";
+import { prisma } from "../../../../../mocks/index.js";
+import { MessageFlags } from "@discordjs/core";
+
+describe("Add Reputation", () => {
+    const guildID = "68239102456844360";
+    const userID = "257522665437265920";
+
+    let command: ReputationCommand;
+    let interaction: ApplicationCommandInteraction;
+
+    beforeEach(() => {
+        const client = createMockApplication();
+        const module = new LevelingModule(client);
+        command = new ReputationCommand(module);
+
+        const data = createMockApplicationCommandInteraction();
+        interaction = new ApplicationCommandInteraction(data, client, vi.fn());
+        interaction.createMessage = vi.fn();
+
+        vi.mocked(prisma.levelingSettings.findUnique).mockResolvedValue({
+            guildID: guildID,
+            enabled: true,
+            ignoredChannels: [],
+            ignoredRoles: []
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe("execute", () => {
+        it("should give reputation to the target user", async () => {
+            const incrementSpy = vi.spyOn(command.module.memberActivity, "increment");
+
+            await command.execute(interaction, {
+                member: mockInteractionMember,
+                user: { ...mockUser, id: userID }
+            });
+
+            expect(incrementSpy).toHaveBeenCalledOnce();
+            expect(incrementSpy).toHaveBeenCalledWith(guildID, userID, {
+                reputation: 1
+            });
+            expect(interaction.createMessage).toHaveBeenCalledOnce();
+            expect(interaction.createMessage).toHaveBeenCalledWith({
+                content: expect.stringContaining(`Gave +1 rep to <@${userID}>.`)
+            });
+        });
+
+        it("should not give reputation to bots", async () => {
+            const incrementSpy = vi.spyOn(command.module.memberActivity, "increment");
+
+            await command.execute(interaction, {
+                member: mockInteractionMember,
+                user: { ...mockUser, bot: true, id: userID }
+            });
+
+            expect(incrementSpy).not.toHaveBeenCalled();
+            expect(interaction.createMessage).toHaveBeenCalledOnce();
+            expect(interaction.createMessage).toHaveBeenCalledWith({
+                content: expect.stringContaining("You cannot give reputation to a bot."),
+                flags: MessageFlags.Ephemeral
+            });
+        });
+
+        it("should not give reputation to the initiator", async () => {
+            const incrementSpy = vi.spyOn(command.module.memberActivity, "increment");
+
+            await command.execute(interaction, {
+                member: mockInteractionMember,
+                user: mockUser
+            });
+
+            expect(incrementSpy).not.toHaveBeenCalled();
+            expect(interaction.createMessage).toHaveBeenCalledOnce();
+            expect(interaction.createMessage).toHaveBeenCalledWith({
+                content: expect.stringContaining("You cannot give yourself reputation."),
+                flags: MessageFlags.Ephemeral
+            });
+        });
+
+        it("should not give reputation to a user with a blacklisted role", async () => {
+            const incrementSpy = vi.spyOn(command.module.memberActivity, "increment");
+            vi.mocked(prisma.levelingSettings.findUnique).mockResolvedValue({
+                guildID: guildID,
+                enabled: true,
+                ignoredChannels: [],
+                ignoredRoles: ["68239102456844360"]
+            });
+
+            await command.execute(interaction, {
+                member: { ...mockInteractionMember, roles: ["68239102456844360"] },
+                user: { ...mockUser, id: userID }
+            });
+
+            expect(incrementSpy).not.toHaveBeenCalled();
+            expect(interaction.createMessage).toHaveBeenCalledOnce();
+            expect(interaction.createMessage).toHaveBeenCalledWith({
+                content: expect.stringContaining("This user cannot receive reputation."),
+                flags: MessageFlags.Ephemeral
+            });
+        });
+
+        it("should not give reputation if the initiator has a blacklisted role", async () => {
+            const incrementSpy = vi.spyOn(command.module.memberActivity, "increment");
+            vi.mocked(prisma.levelingSettings.findUnique).mockResolvedValue({
+                guildID: guildID,
+                enabled: true,
+                ignoredChannels: [],
+                ignoredRoles: ["68239102456844360"]
+            });
+
+            interaction.member = { ...mockInteractionMember, roles: ["68239102456844360"] };
+
+            await command.execute(interaction, {
+                member: mockInteractionMember,
+                user: { ...mockUser, id: userID }
+            });
+
+            expect(incrementSpy).not.toHaveBeenCalled();
+            expect(interaction.createMessage).toHaveBeenCalledOnce();
+            expect(interaction.createMessage).toHaveBeenCalledWith({
+                content: expect.stringContaining("You are not allowed to use this command."),
+                flags: MessageFlags.Ephemeral
+            });
+        });
+
+        it("should ignore if the command was invoked outside a guild", async () => {
+            const incrementSpy = vi.spyOn(command.module.memberActivity, "increment");
+            interaction.guildID = undefined;
+
+            await command.execute(interaction, {
+                member: mockInteractionMember,
+                user: { ...mockUser, id: userID }
+            });
+
+            expect(incrementSpy).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/apps/barry/tests/modules/leveling/commands/user/rep/index.test.ts
+++ b/apps/barry/tests/modules/leveling/commands/user/rep/index.test.ts
@@ -1,13 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createMockApplicationCommandInteraction, mockInteractionMember, mockUser } from "@barry/testing";
+import {
+    createMockApplicationCommandInteraction,
+    mockInteractionMember,
+    mockUser
+} from "@barry/testing";
 
 import { ApplicationCommandInteraction } from "@barry/core";
+import { MessageFlags } from "@discordjs/core";
 import { createMockApplication } from "../../../../../mocks/application.js";
+import { prisma } from "../../../../../mocks/index.js";
 
 import LevelingModule from "../../../../../../src/modules/leveling/index.js";
 import ReputationCommand from "../../../../../../src/modules/leveling/commands/user/rep/index.js";
-import { prisma } from "../../../../../mocks/index.js";
-import { MessageFlags } from "@discordjs/core";
 
 describe("Add Reputation", () => {
     const guildID = "68239102456844360";

--- a/apps/barry/tests/modules/leveling/commands/user/rep/index.test.ts
+++ b/apps/barry/tests/modules/leveling/commands/user/rep/index.test.ts
@@ -13,7 +13,7 @@ import { prisma } from "../../../../../mocks/index.js";
 import LevelingModule from "../../../../../../src/modules/leveling/index.js";
 import ReputationCommand from "../../../../../../src/modules/leveling/commands/user/rep/index.js";
 
-describe("Add Reputation", () => {
+describe("Give Reputation", () => {
     const guildID = "68239102456844360";
     const userID = "257522665437265920";
 


### PR DESCRIPTION
Closes #11.

Adds a user command to give another user reputation. Can only be given once a day.

Since this is the last task of #13, this will also close #13.
