### PR TITLE
chore: clean up code and tests

### DIFF
--- a/apps/barry/prisma/schema.prisma
+++ b/apps/barry/prisma/schema.prisma
@@ -48,7 +48,6 @@ model MemberActivity {
 // Marketplace
 /// Profiles
 enum ProfileCreationStatus {
-  Profile      @map("PROFILE")
   Availability @map("AVAILABILITY")
   Contact      @map("CONTACT")
   Banner       @map("BANNER")

--- a/apps/barry/src/modules/marketplace/dependencies/profiles/events/contactProfile.ts
+++ b/apps/barry/src/modules/marketplace/dependencies/profiles/events/contactProfile.ts
@@ -38,7 +38,7 @@ export default class extends Event<ProfilesModule> {
         const profile = await this.module.profiles.getByMessage(interaction.message.id);
         if (profile === null) {
             return interaction.createMessage({
-                content: `${config.emotes.error} I don't have access to that profile.`,
+                content: `${config.emotes.error} Failed to find the profile you're looking for.`,
                 flags: MessageFlags.Ephemeral
             });
         }

--- a/apps/barry/src/modules/marketplace/dependencies/profiles/events/createProfile.ts
+++ b/apps/barry/src/modules/marketplace/dependencies/profiles/events/createProfile.ts
@@ -55,7 +55,7 @@ export default class extends Event<ProfilesModule> {
             });
         }
 
-        const editor = new ProfileEditor(this.module, false, profile || undefined);
+        const editor = new ProfileEditor(this.module, settings, false, profile || undefined);
         await editor.next(interaction);
     }
 }

--- a/apps/barry/src/modules/marketplace/dependencies/profiles/events/editProfile.ts
+++ b/apps/barry/src/modules/marketplace/dependencies/profiles/events/editProfile.ts
@@ -113,7 +113,7 @@ export default class extends Event<ProfilesModule> {
             return interaction.editParent(timeoutContent);
         }
 
-        const editor = new ProfileEditor(this.module, true, profile);
+        const editor = new ProfileEditor(this.module, settings, true, profile);
         switch (response.data.values[0]) {
             case "availability": {
                 return editor.editAvailability(response);

--- a/apps/barry/tests/Application.test.ts
+++ b/apps/barry/tests/Application.test.ts
@@ -1,4 +1,3 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createMockApplication, mockAppOptions } from "./mocks/application.js";
 
 import { API, GatewayDispatchEvents } from "@discordjs/core";

--- a/apps/barry/tests/mocks/application.ts
+++ b/apps/barry/tests/mocks/application.ts
@@ -1,10 +1,8 @@
-import { Module, UserCommand } from "@barry/core";
-
 import { Application } from "../../src/Application.js";
 import { GatewayIntentBits } from "@discordjs/core";
+import { MockModule } from "./common.js";
 import { prisma } from "./prisma.js";
 import { redis } from "./redis.js";
-import { vi } from "vitest";
 
 vi.mock("ioredis", () => ({
     Redis: vi.fn(() => redis)
@@ -18,33 +16,6 @@ vi.mock("@prisma/client", async (importOriginal) => {
         PrismaClient: vi.fn(() => prisma)
     };
 });
-
-export class MockCommand extends UserCommand {
-    constructor(module: Module) {
-        super(module, {
-            name: "Foo"
-        });
-    }
-
-    async execute(): Promise<void> {
-        // empty...
-    }
-}
-
-export class MockModule extends Module {
-    constructor(client: Application) {
-        super(client, {
-            id: "mock",
-            name: "Mock",
-            description: "Mock module for testing purposes",
-            commands: [MockCommand]
-        });
-    }
-
-    isEnabled(): boolean {
-        return true;
-    }
-}
 
 export const mockAppOptions = {
     discord: {

--- a/apps/barry/tests/mocks/common.ts
+++ b/apps/barry/tests/mocks/common.ts
@@ -1,0 +1,42 @@
+import type { Application } from "../../src/Application.js";
+
+import { Event, Module, UserCommand } from "@barry/core";
+import { GatewayDispatchEvents } from "@discordjs/core";
+
+export class MockCommand extends UserCommand {
+    constructor(module: Module) {
+        super(module, {
+            name: "Foo"
+        });
+    }
+
+    async execute(): Promise<void> {
+        // empty...
+    }
+}
+
+export class MockEvent extends Event {
+    constructor(module: Module) {
+        super(module, GatewayDispatchEvents.InteractionCreate);
+    }
+
+    async execute(): Promise<void> {
+        // empty...
+    }
+}
+
+export class MockModule extends Module {
+    constructor(client: Application) {
+        super(client, {
+            id: "mock",
+            name: "Mock",
+            description: "Mock module for testing purposes",
+            commands: [MockCommand],
+            events: [MockEvent]
+        });
+    }
+
+    isEnabled(): boolean {
+        return true;
+    }
+}

--- a/apps/barry/tests/mocks/index.ts
+++ b/apps/barry/tests/mocks/index.ts
@@ -1,3 +1,4 @@
 export * from "./application.js";
+export * from "./common.js";
 export * from "./prisma.js";
 export * from "./redis.js";

--- a/apps/barry/tests/mocks/prisma.ts
+++ b/apps/barry/tests/mocks/prisma.ts
@@ -1,8 +1,6 @@
 import type { PrismaClient } from "@prisma/client";
 import { mockDeep, mockReset } from "vitest-mock-extended";
 
-import { beforeEach } from "vitest";
-
 beforeEach(() => {
     mockReset(prisma);
 });

--- a/apps/barry/tests/mocks/redis.ts
+++ b/apps/barry/tests/mocks/redis.ts
@@ -1,8 +1,6 @@
 import type { Redis } from "ioredis";
 import { mockDeep, mockReset } from "vitest-mock-extended";
 
-import { beforeEach } from "vitest";
-
 beforeEach(() => {
     mockReset(redis);
 });

--- a/apps/barry/tests/modules/general/commands/chatinput/lipsum/generator.test.ts
+++ b/apps/barry/tests/modules/general/commands/chatinput/lipsum/generator.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from "vitest";
 import {
     generateParagraphs,
     generateSentences,

--- a/apps/barry/tests/modules/general/commands/chatinput/lipsum/index.test.ts
+++ b/apps/barry/tests/modules/general/commands/chatinput/lipsum/index.test.ts
@@ -1,13 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import { ApplicationCommandInteraction } from "@barry/core";
 import { createMockApplicationCommandInteraction } from "@barry/testing";
 import { createMockApplication } from "../../../../../mocks/index.js";
 
-import * as generator from "../../../../../../src/modules/general/commands/chatinput/lipsum/generator.js";
-
 import GeneralModule from "../../../../../../src/modules/general/index.js";
 import LipsumCommand from "../../../../../../src/modules/general/commands/chatinput/lipsum/index.js";
+
+import * as generator from "../../../../../../src/modules/general/commands/chatinput/lipsum/generator.js";
 
 describe("/lipsum", () => {
     let command: LipsumCommand;

--- a/apps/barry/tests/modules/general/commands/chatinput/ping/index.test.ts
+++ b/apps/barry/tests/modules/general/commands/chatinput/ping/index.test.ts
@@ -1,5 +1,4 @@
 import { ApplicationCommandInteraction, getCreatedAt } from "@barry/core";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMockApplicationCommandInteraction, mockMessage } from "@barry/testing";
 import { createMockApplication } from "../../../../../mocks/index.js";
 

--- a/apps/barry/tests/modules/general/commands/chatinput/reverse/image/index.test.ts
+++ b/apps/barry/tests/modules/general/commands/chatinput/reverse/image/index.test.ts
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMockApplicationCommandInteraction, mockAttachment } from "@barry/testing";
 
 import { ApplicationCommandInteraction } from "@barry/core";

--- a/apps/barry/tests/modules/general/commands/message/reverse/index.test.ts
+++ b/apps/barry/tests/modules/general/commands/message/reverse/index.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ComponentType, MessageFlags } from "@discordjs/core";
 import {
     createMockApplicationCommandInteraction,
     mockAttachment,
@@ -6,7 +6,6 @@ import {
 } from "@barry/testing";
 
 import { ApplicationCommandInteraction } from "@barry/core";
-import { ComponentType, MessageFlags } from "@discordjs/core";
 import { createMockApplication } from "../../../../../mocks/index.js";
 
 import GeneralModule from "../../../../../../src/modules/general/index.js";

--- a/apps/barry/tests/modules/general/commands/user/avatar/index.test.ts
+++ b/apps/barry/tests/modules/general/commands/user/avatar/index.test.ts
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMockApplicationCommandInteraction, mockUser } from "@barry/testing";
 
 import { ApplicationCommandInteraction } from "@barry/core";

--- a/apps/barry/tests/modules/general/commands/user/reverse/index.test.ts
+++ b/apps/barry/tests/modules/general/commands/user/reverse/index.test.ts
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMockApplicationCommandInteraction, mockUser } from "@barry/testing";
 
 import { ApplicationCommandInteraction } from "@barry/core";

--- a/apps/barry/tests/modules/general/functions/reverse/getReverseContent.test.ts
+++ b/apps/barry/tests/modules/general/functions/reverse/getReverseContent.test.ts
@@ -1,5 +1,3 @@
-import { describe, expect, it } from "vitest";
-
 import { MessageFlags } from "@discordjs/core";
 import { getReverseContent } from "../../../../../src/modules/general/functions/reverse/getReverseContent.js";
 import { mockAttachment } from "@barry/testing";

--- a/apps/barry/tests/modules/general/index.test.ts
+++ b/apps/barry/tests/modules/general/index.test.ts
@@ -1,5 +1,3 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
 import { ApplicationCommandInteraction, Module } from "@barry/core";
 import { MessageFlags } from "@discordjs/core";
 import { createMockApplicationCommandInteraction } from "@barry/testing";

--- a/apps/barry/tests/modules/leveling/commands/chatinput/leaderboard/LeaderboardCanvas.test.ts
+++ b/apps/barry/tests/modules/leveling/commands/chatinput/leaderboard/LeaderboardCanvas.test.ts
@@ -1,7 +1,6 @@
 import { type Canvas, loadImage } from "canvas-constructor/napi-rs";
 import type { MemberActivity } from "@prisma/client";
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mockMessage, mockUser } from "@barry/testing";
 
 import { LeaderboardCanvas } from "../../../../../../src/modules/leveling/commands/chatinput/leaderboard/LeaderboardCanvas.js";

--- a/apps/barry/tests/modules/leveling/commands/chatinput/leaderboard/index.test.ts
+++ b/apps/barry/tests/modules/leveling/commands/chatinput/leaderboard/index.test.ts
@@ -7,7 +7,6 @@ import {
 } from "@barry/core";
 import { ComponentType, MessageFlags } from "@discordjs/core";
 import { MemberActivitySortBy, MemberActivitySortOrder } from "../../../../../../src/modules/leveling/database.js";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
     createMockApplicationCommandInteraction,
     createMockMessageComponentInteraction,

--- a/apps/barry/tests/modules/leveling/commands/user/rank/index.test.ts
+++ b/apps/barry/tests/modules/leveling/commands/user/rank/index.test.ts
@@ -1,5 +1,4 @@
 import { Canvas, loadImage } from "canvas-constructor/napi-rs";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createMockApplicationCommandInteraction, mockUser } from "@barry/testing";
 
 import { ApplicationCommandInteraction } from "@barry/core";

--- a/apps/barry/tests/modules/leveling/commands/user/rep/index.test.ts
+++ b/apps/barry/tests/modules/leveling/commands/user/rep/index.test.ts
@@ -1,4 +1,3 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
     createMockApplicationCommandInteraction,
     mockInteractionMember,

--- a/apps/barry/tests/modules/leveling/database.test.ts
+++ b/apps/barry/tests/modules/leveling/database.test.ts
@@ -12,7 +12,6 @@ import {
     MemberActivitySortBy,
     MemberActivitySortOrder
 } from "../../../src/modules/leveling/database.js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { prisma } from "../../mocks/index.js";
 

--- a/apps/barry/tests/modules/leveling/events/messageCreate.test.ts
+++ b/apps/barry/tests/modules/leveling/events/messageCreate.test.ts
@@ -1,7 +1,10 @@
 import type { GatewayMessageCreateDispatchData } from "@discordjs/core";
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { mockMember, mockMessage, mockUser } from "@barry/testing";
+import {
+    mockMember,
+    mockMessage,
+    mockUser
+} from "@barry/testing";
 
 import { DiscordAPIError } from "@discordjs/rest";
 import { createMockApplication } from "../../../mocks/application.js";

--- a/apps/barry/tests/modules/leveling/events/voiceStateUpdate.test.ts
+++ b/apps/barry/tests/modules/leveling/events/voiceStateUpdate.test.ts
@@ -1,8 +1,6 @@
 import type { GatewayVoiceState } from "@discordjs/core";
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { prisma, redis } from "../../../mocks/index.js";
-
 import { DiscordAPIError } from "@discordjs/rest";
 import { createMockApplication } from "../../../mocks/application.js";
 import { mockMember } from "@barry/testing";

--- a/apps/barry/tests/modules/leveling/index.test.ts
+++ b/apps/barry/tests/modules/leveling/index.test.ts
@@ -1,5 +1,4 @@
 import { type MemberActivity, LevelUpNotificationType } from "@prisma/client";
-
 import type { APIChannel } from "@discordjs/core";
 
 import {
@@ -7,7 +6,6 @@ import {
     LevelingSettingsRepository,
     MemberActivityRepository
 } from "../../../src/modules/leveling/database.js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMockApplication } from "../../mocks/application.js";
 
 import LevelingModule from "../../../src/modules/leveling/index.js";

--- a/apps/barry/tests/modules/marketplace/constants.test.ts
+++ b/apps/barry/tests/modules/marketplace/constants.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from "vitest";
 import { INVITE_REGEX } from "../../../src/modules/marketplace/constants.js";
 
 describe("INVITE_REGEX", () => {

--- a/apps/barry/tests/modules/marketplace/index.test.ts
+++ b/apps/barry/tests/modules/marketplace/index.test.ts
@@ -1,6 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
 import { createMockApplication } from "../../mocks/application.js";
-
 import MarketplaceModule from "../../../src/modules/marketplace/index.js";
 
 describe("MarketplaceModule", () => {

--- a/apps/barry/tests/modules/marketplace/profiles/database.test.ts
+++ b/apps/barry/tests/modules/marketplace/profiles/database.test.ts
@@ -1,11 +1,11 @@
+import type { ProfilesSettings } from "@prisma/client";
+
 import {
     ProfileMessageRepository,
     ProfileRepository,
     ProfilesSettingsRepository
 } from "../../../../src/modules/marketplace/dependencies/profiles/database.js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ProfilesSettings } from "@prisma/client";
 import { mockChannel } from "@barry/testing";
 import { mockProfile } from "./mocks/profile.js";
 import { prisma } from "../../../mocks/index.js";

--- a/apps/barry/tests/modules/marketplace/profiles/editor/ProfileEditor.test.ts
+++ b/apps/barry/tests/modules/marketplace/profiles/editor/ProfileEditor.test.ts
@@ -1139,7 +1139,7 @@ describe("ProfileEditor", () => {
                 expect(module.postProfile).toHaveBeenCalledWith(mockUser, mockProfile, settings);
             });
 
-            it("should show an error message if the profiles are disabled in the guild", async () => {
+            it("should show an error message if the module is disabled in the guild", async () => {
                 const data = createMockMessageComponentInteraction({
                     component_type: ComponentType.Button,
                     custom_id: "publish"
@@ -1162,7 +1162,7 @@ describe("ProfileEditor", () => {
                 });
             });
 
-            it("should show an error message if the guild has not set a channel for profiles", async () => {
+            it("should show an error message if the guild has not configured a channel for profiles", async () => {
                 const data = createMockMessageComponentInteraction({
                     component_type: ComponentType.Button,
                     custom_id: "publish"

--- a/apps/barry/tests/modules/marketplace/profiles/editor/ProfileEditor.test.ts
+++ b/apps/barry/tests/modules/marketplace/profiles/editor/ProfileEditor.test.ts
@@ -859,17 +859,6 @@ describe("ProfileEditor", () => {
             expect(editor.showPreview).toHaveBeenCalledWith(interaction);
         });
 
-        it("should edit the profile if the creation status is set to 'Profile'", async () => {
-            const profile = { ...mockProfile, creationStatus: ProfileCreationStatus.Profile };
-            const editor = new ProfileEditor(module, settings, false, profile);
-            editor.editProfile = vi.fn();
-
-            await editor.next(interaction);
-
-            expect(editor.editProfile).toHaveBeenCalledOnce();
-            expect(editor.editProfile).toHaveBeenCalledWith(interaction);
-        });
-
         it("should edit the availability if the creation status is set to 'Availability'", async () => {
             const profile = { ...mockProfile, creationStatus: ProfileCreationStatus.Availability };
             const editor = new ProfileEditor(module, settings, false, profile);

--- a/apps/barry/tests/modules/marketplace/profiles/editor/ProfileEditor.test.ts
+++ b/apps/barry/tests/modules/marketplace/profiles/editor/ProfileEditor.test.ts
@@ -26,6 +26,7 @@ import * as utils from "../../../../../src/modules/marketplace/utils.js";
 describe("ProfileEditor", () => {
     let interaction: UpdatableInteraction;
     let module: ProfilesModule;
+    let settings: ProfilesSettings;
 
     beforeEach(() => {
         const client = createMockApplication();
@@ -34,6 +35,14 @@ describe("ProfileEditor", () => {
         const data = createMockModalSubmitInteraction();
         interaction = new UpdatableInteraction(data, client, vi.fn());
 
+        settings = {
+            channelID: mockChannel.id,
+            enabled: true,
+            guildID: "68239102456844360",
+            lastMessageID: null
+        };
+
+        vi.spyOn(module.profilesSettings, "get").mockResolvedValue(settings);
         vi.spyOn(client.api.users, "createDM").mockResolvedValue({ ...mockChannel, position: 0 });
         vi.spyOn(client.api.channels, "createMessage").mockResolvedValue(mockMessage);
         vi.spyOn(client.api.channels, "editMessage").mockResolvedValue(mockMessage);
@@ -53,15 +62,14 @@ describe("ProfileEditor", () => {
             );
 
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, true, mockProfile);
+            const editor = new ProfileEditor(module, settings, true, mockProfile);
             editor.next = vi.fn();
 
             await editor.editAvailability(interaction);
 
             expect(upsertSpy).toHaveBeenCalledOnce();
             expect(upsertSpy).toHaveBeenCalledWith(mockUser.id, {
-                availability: 41,
-                creationStatus: null
+                availability: 41
             });
         });
 
@@ -77,7 +85,7 @@ describe("ProfileEditor", () => {
             );
 
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
             editor.next = vi.fn();
 
             await editor.editAvailability(interaction);
@@ -100,7 +108,7 @@ describe("ProfileEditor", () => {
             vi.spyOn(interaction, "awaitMessageComponent").mockResolvedValue(response);
 
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
             editor.next = vi.fn();
 
             await editor.editAvailability(interaction);
@@ -119,7 +127,7 @@ describe("ProfileEditor", () => {
 
             const editSpy = vi.spyOn(interaction, "editParent");
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
 
             await editor.editAvailability(interaction);
 
@@ -139,7 +147,7 @@ describe("ProfileEditor", () => {
             );
 
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, true, mockProfile);
+            const editor = new ProfileEditor(module, settings, true, mockProfile);
 
             await editor.editAvailability(interaction);
 
@@ -173,15 +181,14 @@ describe("ProfileEditor", () => {
             });
 
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, true, mockProfile);
+            const editor = new ProfileEditor(module, settings, true, mockProfile);
             editor.showPreview = vi.fn();
 
             await editor.editBanner(interaction, mockChannel.id, true);
 
             expect(upsertSpy).toHaveBeenCalledOnce();
             expect(upsertSpy).toHaveBeenCalledWith(mockUser.id, {
-                bannerURL: "https://example.com/new-banner.png",
-                creationStatus: null
+                bannerURL: "https://example.com/new-banner.png"
             });
         });
 
@@ -199,7 +206,7 @@ describe("ProfileEditor", () => {
             });
 
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
             editor.showPreview = vi.fn();
 
             await editor.editBanner(interaction, mockChannel.id, true);
@@ -217,7 +224,7 @@ describe("ProfileEditor", () => {
 
             const editSpy = vi.spyOn(interaction, "editParent");
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
             editor.showPreview = vi.fn();
 
             await editor.editBanner(interaction, mockChannel.id, true);
@@ -255,7 +262,7 @@ describe("ProfileEditor", () => {
                 .mockResolvedValue(mockMessage);
 
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
             const bannerSpy = vi.spyOn(editor, "editBanner");
             editor.showPreview = vi.fn();
 
@@ -281,7 +288,7 @@ describe("ProfileEditor", () => {
             );
 
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
             editor.showPreview = vi.fn();
 
             await editor.editBanner(interaction, mockChannel.id, true);
@@ -298,12 +305,12 @@ describe("ProfileEditor", () => {
 
             const createSpy = vi.spyOn(module.client.api.channels, "createMessage");
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
             editor.showPreview = vi.fn();
 
             await editor.editBanner(interaction, mockChannel.id, true);
 
-            expect(createSpy).toHaveBeenCalledTimes(3);
+            expect(createSpy).toHaveBeenCalledTimes(2);
             expect(createSpy).toHaveBeenCalledWith(mockChannel.id, {
                 components: retryComponents,
                 content: expect.stringContaining("There are no images in that message.")
@@ -335,7 +342,7 @@ describe("ProfileEditor", () => {
             );
 
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
             editor.showPreview = vi.fn();
 
             await editor.editBanner(interaction, mockChannel.id, true);
@@ -359,7 +366,7 @@ describe("ProfileEditor", () => {
             );
 
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
             editor.showPreview = vi.fn();
 
             await editor.editBanner(interaction, mockChannel.id, true);
@@ -376,7 +383,7 @@ describe("ProfileEditor", () => {
 
             const createSpy = vi.spyOn(module.client.api.channels, "createMessage");
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
             editor.showPreview = vi.fn();
 
             await editor.editBanner(interaction, mockChannel.id, true);
@@ -406,15 +413,14 @@ describe("ProfileEditor", () => {
             );
 
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, true, mockProfile);
+            const editor = new ProfileEditor(module, settings, true, mockProfile);
             editor.next = vi.fn();
 
             await editor.editContact(interaction);
 
             expect(upsertSpy).toHaveBeenCalledOnce();
             expect(upsertSpy).toHaveBeenCalledWith(mockUser.id, {
-                contact: "Send me a direct message!",
-                creationStatus: null
+                contact: "Send me a direct message!"
             });
         });
 
@@ -436,7 +442,7 @@ describe("ProfileEditor", () => {
             );
 
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
             editor.next = vi.fn();
 
             await editor.editContact(interaction);
@@ -465,7 +471,7 @@ describe("ProfileEditor", () => {
             vi.spyOn(interaction, "awaitModalSubmit").mockResolvedValue(response);
 
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
             editor.next = vi.fn();
 
             await editor.editContact(interaction);
@@ -497,7 +503,7 @@ describe("ProfileEditor", () => {
             );
 
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
             editor.next = vi.fn();
 
             await editor.editContact(interaction);
@@ -514,7 +520,7 @@ describe("ProfileEditor", () => {
 
             const editSpy = vi.spyOn(interaction, "editParent");
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
 
             await editor.editContact(interaction);
 
@@ -541,7 +547,7 @@ describe("ProfileEditor", () => {
 
             const createSpy = vi.spyOn(response, "createMessage");
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
 
             await editor.editContact(interaction);
 
@@ -607,7 +613,7 @@ describe("ProfileEditor", () => {
             );
 
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, true, mockProfile);
+            const editor = new ProfileEditor(module, settings, true, mockProfile);
             editor.next = vi.fn();
 
             await editor.editProfile(interaction);
@@ -674,7 +680,7 @@ describe("ProfileEditor", () => {
             );
 
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
             editor.next = vi.fn();
 
             await editor.editProfile(interaction);
@@ -741,7 +747,7 @@ describe("ProfileEditor", () => {
             vi.spyOn(interaction, "awaitModalSubmit").mockResolvedValue(response);
 
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
             editor.next = vi.fn();
 
             await editor.editProfile(interaction);
@@ -811,7 +817,7 @@ describe("ProfileEditor", () => {
             );
 
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
             editor.next = vi.fn();
 
             await editor.editProfile(interaction);
@@ -832,7 +838,7 @@ describe("ProfileEditor", () => {
 
             const editSpy = vi.spyOn(interaction, "editParent");
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
 
             await editor.editProfile(interaction);
 
@@ -844,7 +850,7 @@ describe("ProfileEditor", () => {
 
     describe("next", () => {
         it("should show the preview if they are editing their profile", async () => {
-            const editor = new ProfileEditor(module, true, mockProfile);
+            const editor = new ProfileEditor(module, settings, true, mockProfile);
             editor.showPreview = vi.fn();
 
             await editor.next(interaction);
@@ -855,7 +861,7 @@ describe("ProfileEditor", () => {
 
         it("should edit the profile if the creation status is set to 'Profile'", async () => {
             const profile = { ...mockProfile, creationStatus: ProfileCreationStatus.Profile };
-            const editor = new ProfileEditor(module, false, profile);
+            const editor = new ProfileEditor(module, settings, false, profile);
             editor.editProfile = vi.fn();
 
             await editor.next(interaction);
@@ -866,7 +872,7 @@ describe("ProfileEditor", () => {
 
         it("should edit the availability if the creation status is set to 'Availability'", async () => {
             const profile = { ...mockProfile, creationStatus: ProfileCreationStatus.Availability };
-            const editor = new ProfileEditor(module, false, profile);
+            const editor = new ProfileEditor(module, settings, false, profile);
             editor.editAvailability = vi.fn();
 
             await editor.next(interaction);
@@ -877,7 +883,7 @@ describe("ProfileEditor", () => {
 
         it("should edit the contact information if the creation status is set to 'Contact'", async () => {
             const profile = { ...mockProfile, creationStatus: ProfileCreationStatus.Contact };
-            const editor = new ProfileEditor(module, false, profile);
+            const editor = new ProfileEditor(module, settings, false, profile);
             editor.editContact = vi.fn();
 
             await editor.next(interaction);
@@ -888,7 +894,7 @@ describe("ProfileEditor", () => {
 
         it("should edit the banner if the creation status is set to 'Banner'", async () => {
             const profile = { ...mockProfile, creationStatus: ProfileCreationStatus.Banner };
-            const editor = new ProfileEditor(module, false, profile);
+            const editor = new ProfileEditor(module, settings, false, profile);
             editor.promptBanner = vi.fn();
 
             await editor.next(interaction);
@@ -899,7 +905,7 @@ describe("ProfileEditor", () => {
 
         it("should show the preview if the creation status is set to 'Preview'", async () => {
             const profile = { ...mockProfile, creationStatus: ProfileCreationStatus.Preview };
-            const editor = new ProfileEditor(module, false, profile);
+            const editor = new ProfileEditor(module, settings, false, profile);
             editor.showPreview = vi.fn();
 
             await editor.next(interaction);
@@ -909,7 +915,7 @@ describe("ProfileEditor", () => {
         });
 
         it("should start creating a profile if no profile exists yet", async () => {
-            const editor = new ProfileEditor(module, false);
+            const editor = new ProfileEditor(module, settings, false);
             editor.editProfile = vi.fn();
 
             await editor.next(interaction);
@@ -929,7 +935,7 @@ describe("ProfileEditor", () => {
             const response = new MessageComponentInteraction(data, module.client, vi.fn());
             vi.spyOn(interaction, "awaitMessageComponent").mockResolvedValue(response);
 
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
             editor.editBanner = vi.fn();
 
             await editor.promptBanner(interaction);
@@ -948,7 +954,7 @@ describe("ProfileEditor", () => {
             vi.spyOn(interaction, "awaitMessageComponent").mockResolvedValue(response);
 
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
             editor.showPreview = vi.fn();
 
             await editor.promptBanner(interaction);
@@ -966,7 +972,7 @@ describe("ProfileEditor", () => {
 
             const editSpy = vi.spyOn(interaction, "editParent");
             const upsertSpy = vi.spyOn(module.profiles, "upsert");
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
 
             await editor.promptBanner(interaction);
 
@@ -981,7 +987,7 @@ describe("ProfileEditor", () => {
             vi.spyOn(interaction, "awaitMessageComponent").mockResolvedValue(undefined);
 
             const editSpy = vi.spyOn(interaction, "editOriginalMessage");
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
 
             await editor.showPreview(interaction);
 
@@ -1012,7 +1018,7 @@ describe("ProfileEditor", () => {
 
             const createSpy = vi.spyOn(module.client.api.channels, "createMessage");
             const editSpy = vi.spyOn(interaction, "editOriginalMessage");
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
 
             await editor.showPreview(interaction, mockChannel.id);
 
@@ -1024,7 +1030,7 @@ describe("ProfileEditor", () => {
             vi.spyOn(interaction, "awaitMessageComponent").mockResolvedValue(undefined);
 
             const getSpy = vi.spyOn(module.profiles, "get").mockResolvedValue(mockProfile);
-            const editor = new ProfileEditor(module, false);
+            const editor = new ProfileEditor(module, settings, false);
 
             await editor.showPreview(interaction, mockChannel.id);
 
@@ -1035,13 +1041,13 @@ describe("ProfileEditor", () => {
             vi.spyOn(module.profiles, "get").mockResolvedValue(null);
 
             const createSpy = vi.spyOn(interaction, "createMessage");
-            const editor = new ProfileEditor(module, false);
+            const editor = new ProfileEditor(module, settings, false);
 
             await editor.showPreview(interaction, mockChannel.id);
 
             expect(createSpy).toHaveBeenCalledOnce();
             expect(createSpy).toHaveBeenCalledWith({
-                content: expect.stringContaining("I don't have access to that profile."),
+                content: expect.stringContaining("Failed to find the profile you're looking for."),
                 flags: MessageFlags.Ephemeral
             });
         });
@@ -1052,7 +1058,7 @@ describe("ProfileEditor", () => {
             vi.spyOn(interaction, "awaitMessageComponent").mockResolvedValue(undefined);
 
             const editSpy = vi.spyOn(interaction, "editParent");
-            const editor = new ProfileEditor(module, false, mockProfile);
+            const editor = new ProfileEditor(module, settings, false, mockProfile);
 
             await editor.showPreview(interaction, mockChannel.id);
 
@@ -1061,19 +1067,6 @@ describe("ProfileEditor", () => {
         });
 
         describe("Publish", () => {
-            let settings: ProfilesSettings;
-
-            beforeEach(() => {
-                settings = {
-                    channelID: mockChannel.id,
-                    enabled: true,
-                    guildID: "68239102456844360",
-                    lastMessageID: null
-                };
-
-                vi.spyOn(module.profilesSettings, "get").mockResolvedValue(settings);
-            });
-
             it("should post the profile if the user is creating a new profile", async () => {
                 const data = createMockMessageComponentInteraction({
                     component_type: ComponentType.Button,
@@ -1085,7 +1078,7 @@ describe("ProfileEditor", () => {
                     new MessageComponentInteraction(data, module.client, vi.fn())
                 );
 
-                const editor = new ProfileEditor(module, false, mockProfile);
+                const editor = new ProfileEditor(module, settings, false, mockProfile);
                 module.postProfile = vi.fn();
 
                 await editor.showPreview(interaction);
@@ -1110,7 +1103,7 @@ describe("ProfileEditor", () => {
                 );
 
                 const editSpy = vi.spyOn(module.client.api.channels, "editMessage");
-                const editor = new ProfileEditor(module, true, mockProfile);
+                const editor = new ProfileEditor(module, settings, true, mockProfile);
 
                 await editor.showPreview(interaction);
 
@@ -1130,36 +1123,13 @@ describe("ProfileEditor", () => {
                     new MessageComponentInteraction(data, module.client, vi.fn())
                 );
 
-                const editor = new ProfileEditor(module, true, mockProfile);
+                const editor = new ProfileEditor(module, settings, true, mockProfile);
                 module.postProfile = vi.fn();
 
                 await editor.showPreview(interaction);
 
                 expect(module.postProfile).toHaveBeenCalledOnce();
                 expect(module.postProfile).toHaveBeenCalledWith(mockUser, mockProfile, settings);
-            });
-
-            it("should show an error message if the module is disabled in the guild", async () => {
-                const data = createMockMessageComponentInteraction({
-                    component_type: ComponentType.Button,
-                    custom_id: "publish"
-                });
-
-                vi.spyOn(interaction, "awaitMessageComponent").mockResolvedValue(
-                    new MessageComponentInteraction(data, module.client, vi.fn())
-                );
-
-                const createSpy = vi.spyOn(interaction, "createMessage");
-                const editor = new ProfileEditor(module, true, mockProfile);
-                settings.enabled = false;
-
-                await editor.showPreview(interaction);
-
-                expect(createSpy).toHaveBeenCalledOnce();
-                expect(createSpy).toHaveBeenCalledWith({
-                    content: expect.stringContaining("Profiles are currently disabled for this guild."),
-                    flags: MessageFlags.Ephemeral
-                });
             });
 
             it("should show an error message if the guild has not configured a channel for profiles", async () => {
@@ -1173,7 +1143,7 @@ describe("ProfileEditor", () => {
                 );
 
                 const createSpy = vi.spyOn(interaction, "createMessage");
-                const editor = new ProfileEditor(module, true, mockProfile);
+                const editor = new ProfileEditor(module, settings, true, mockProfile);
                 settings.channelID = null;
 
                 await editor.showPreview(interaction);
@@ -1202,31 +1172,12 @@ describe("ProfileEditor", () => {
                 );
 
                 const loggerSpy = vi.spyOn(module.client.logger, "warn");
-                const editor = new ProfileEditor(module, true, mockProfile);
+                const editor = new ProfileEditor(module, settings, true, mockProfile);
 
                 await editor.showPreview(interaction);
 
                 expect(loggerSpy).toHaveBeenCalledOnce();
                 expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining("Could not edit last message"));
-            });
-
-            it("should ignore if the ID of the guild is unknown", async () => {
-                const data = createMockMessageComponentInteraction({
-                    component_type: ComponentType.Button,
-                    custom_id: "publish"
-                });
-
-                vi.spyOn(interaction, "awaitMessageComponent").mockResolvedValue(
-                    new MessageComponentInteraction(data, module.client, vi.fn())
-                );
-
-                const editor = new ProfileEditor(module, true, mockProfile);
-                interaction.guildID = undefined;
-                module.postProfile = vi.fn();
-
-                await editor.showPreview(interaction);
-
-                expect(module.postProfile).not.toHaveBeenCalled();
             });
         });
 
@@ -1242,7 +1193,7 @@ describe("ProfileEditor", () => {
                 vi.spyOn(response, "awaitMessageComponent").mockResolvedValue(undefined);
                 vi.spyOn(response, "editOriginalMessage").mockResolvedValue(mockMessage);
 
-                const editor = new ProfileEditor(module, false, mockProfile);
+                const editor = new ProfileEditor(module, settings, false, mockProfile);
                 await editor.showPreview(interaction);
 
                 expect(editor.isEditing).toBe(true);
@@ -1261,7 +1212,7 @@ describe("ProfileEditor", () => {
                 vi.spyOn(response, "awaitMessageComponent").mockResolvedValue(undefined);
                 vi.spyOn(response, "editOriginalMessage").mockResolvedValue(mockMessage);
 
-                const editor = new ProfileEditor(module, false, mockProfile);
+                const editor = new ProfileEditor(module, settings, false, mockProfile);
                 await editor.showPreview(interaction);
 
                 expect(editSpy).toHaveBeenCalledTimes(2);
@@ -1287,7 +1238,7 @@ describe("ProfileEditor", () => {
                 vi.spyOn(response, "awaitMessageComponent").mockResolvedValue(editResponse);
                 vi.spyOn(response, "editOriginalMessage").mockResolvedValue(mockMessage);
 
-                const editor = new ProfileEditor(module, false, mockProfile);
+                const editor = new ProfileEditor(module, settings, false, mockProfile);
                 editor.editAvailability = vi.fn();
 
                 await editor.showPreview(interaction);
@@ -1315,7 +1266,7 @@ describe("ProfileEditor", () => {
                 vi.spyOn(response, "awaitMessageComponent").mockResolvedValue(editResponse);
                 vi.spyOn(response, "editOriginalMessage").mockResolvedValue(mockMessage);
 
-                const editor = new ProfileEditor(module, false, mockProfile);
+                const editor = new ProfileEditor(module, settings, false, mockProfile);
                 editor.editBanner = vi.fn();
 
                 await editor.showPreview(interaction);
@@ -1343,7 +1294,7 @@ describe("ProfileEditor", () => {
                 vi.spyOn(response, "awaitMessageComponent").mockResolvedValue(editResponse);
                 vi.spyOn(response, "editOriginalMessage").mockResolvedValue(mockMessage);
 
-                const editor = new ProfileEditor(module, false, mockProfile);
+                const editor = new ProfileEditor(module, settings, false, mockProfile);
                 editor.editContact = vi.fn();
 
                 await editor.showPreview(interaction);
@@ -1371,7 +1322,7 @@ describe("ProfileEditor", () => {
                 vi.spyOn(response, "awaitMessageComponent").mockResolvedValue(editResponse);
                 vi.spyOn(response, "editOriginalMessage").mockResolvedValue(mockMessage);
 
-                const editor = new ProfileEditor(module, false, mockProfile);
+                const editor = new ProfileEditor(module, settings, false, mockProfile);
                 editor.editProfile = vi.fn();
 
                 await editor.showPreview(interaction);
@@ -1400,7 +1351,7 @@ describe("ProfileEditor", () => {
                 vi.spyOn(response, "awaitMessageComponent").mockResolvedValue(editResponse);
                 vi.spyOn(response, "editOriginalMessage").mockResolvedValue(mockMessage);
 
-                const editor = new ProfileEditor(module, false, mockProfile);
+                const editor = new ProfileEditor(module, settings, false, mockProfile);
                 editor.editBanner = vi.fn();
 
                 await editor.showPreview(interaction, mockChannel.id);
@@ -1423,7 +1374,7 @@ describe("ProfileEditor", () => {
                     .mockResolvedValue(undefined);
                 vi.spyOn(response, "editOriginalMessage").mockResolvedValue(mockMessage);
 
-                const editor = new ProfileEditor(module, false, mockProfile);
+                const editor = new ProfileEditor(module, settings, false, mockProfile);
                 const displaySpy = vi.spyOn(utils, "displayContact").mockResolvedValue();
 
                 await editor.showPreview(interaction);
@@ -1443,7 +1394,7 @@ describe("ProfileEditor", () => {
                     .mockResolvedValueOnce(new MessageComponentInteraction(data, module.client, vi.fn()))
                     .mockResolvedValue(undefined);
 
-                const editor = new ProfileEditor(module, false, mockProfile);
+                const editor = new ProfileEditor(module, settings, false, mockProfile);
                 const displaySpy = vi.spyOn(utils, "displayContact").mockResolvedValue();
 
                 await editor.showPreview(interaction);

--- a/apps/barry/tests/modules/marketplace/profiles/editor/ProfileEditor.test.ts
+++ b/apps/barry/tests/modules/marketplace/profiles/editor/ProfileEditor.test.ts
@@ -6,7 +6,6 @@ import {
     ModalSubmitInteraction,
     UpdatableInteraction
 } from "@barry/core";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
     createMockMessageComponentInteraction,
     createMockModalSubmitInteraction,

--- a/apps/barry/tests/modules/marketplace/profiles/editor/availability.test.ts
+++ b/apps/barry/tests/modules/marketplace/profiles/editor/availability.test.ts
@@ -1,5 +1,4 @@
 import { ProfileAvailability, getEmoji } from "../../../../../src/modules/marketplace/dependencies/profiles/editor/availability.js";
-import { describe, expect, it } from "vitest";
 
 describe("Availability", () => {
     describe("getEmoji", () => {

--- a/apps/barry/tests/modules/marketplace/profiles/editor/functions/content.test.ts
+++ b/apps/barry/tests/modules/marketplace/profiles/editor/functions/content.test.ts
@@ -1,6 +1,5 @@
 import { ComponentType, MessageFlags, TextInputStyle } from "@discordjs/core";
 import { ProfileAvailability, combinations } from "../../../../../../src/modules/marketplace/dependencies/profiles/editor/availability.js";
-import { afterEach, describe, expect, it, vi } from "vitest";
 import {
     getEditAvailabilityContent,
     getEditContactContent,

--- a/apps/barry/tests/modules/marketplace/profiles/editor/functions/parseLink.test.ts
+++ b/apps/barry/tests/modules/marketplace/profiles/editor/functions/parseLink.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, test } from "vitest";
 import { parseLink } from "../../../../../../src/modules/marketplace/dependencies/profiles/editor/functions/parseLink.js";
 
 describe("parseLink", () => {

--- a/apps/barry/tests/modules/marketplace/profiles/editor/functions/utils.test.ts
+++ b/apps/barry/tests/modules/marketplace/profiles/editor/functions/utils.test.ts
@@ -1,7 +1,6 @@
-import { APIModalSubmitInteraction, ComponentType } from "@discordjs/core";
-import { URL_REGEX, parseProfileData } from "../../../../../../src/modules/marketplace/dependencies/profiles/editor/functions/utils.js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type APIModalSubmitInteraction, ComponentType } from "@discordjs/core";
 
+import { URL_REGEX, parseProfileData } from "../../../../../../src/modules/marketplace/dependencies/profiles/editor/functions/utils.js";
 import { Application } from "../../../../../../src/Application.js";
 import { ModalSubmitInteraction } from "@barry/core";
 import { createMockApplication } from "../../../../../mocks/application.js";

--- a/apps/barry/tests/modules/marketplace/profiles/events/contactProfile.test.ts
+++ b/apps/barry/tests/modules/marketplace/profiles/events/contactProfile.test.ts
@@ -105,7 +105,7 @@ describe("Contact (InteractionCreate) Event", () => {
 
             expect(createSpy).toHaveBeenCalledOnce();
             expect(createSpy).toHaveBeenCalledWith({
-                content: expect.stringContaining("I don't have access to that profile."),
+                content: expect.stringContaining("Failed to find the profile you're looking for."),
                 flags: MessageFlags.Ephemeral
             });
         });

--- a/apps/barry/tests/modules/marketplace/profiles/events/contactProfile.test.ts
+++ b/apps/barry/tests/modules/marketplace/profiles/events/contactProfile.test.ts
@@ -77,7 +77,7 @@ describe("Contact (InteractionCreate) Event", () => {
             expect(settingsSpy).not.toHaveBeenCalled();
         });
 
-        it("should ignore if the interaction is not the contact button", async () => {
+        it("should ignore if the interaction does not come from the 'Contact' button", async () => {
             const data = createMockMessageComponentInteraction({
                 component_type: ComponentType.Button,
                 custom_id: ProfileActionButton.Report

--- a/apps/barry/tests/modules/marketplace/profiles/events/contactProfile.test.ts
+++ b/apps/barry/tests/modules/marketplace/profiles/events/contactProfile.test.ts
@@ -1,6 +1,5 @@
 import { ComponentType, MessageFlags } from "@discordjs/core";
 import { MessageComponentInteraction, PingInteraction } from "@barry/core";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
     createMockMessageComponentInteraction,
     mockPingInteraction

--- a/apps/barry/tests/modules/marketplace/profiles/events/createProfile.test.ts
+++ b/apps/barry/tests/modules/marketplace/profiles/events/createProfile.test.ts
@@ -88,7 +88,7 @@ describe("Create Profile (InteractionCreate) Event", () => {
             expect(settingsSpy).not.toHaveBeenCalled();
         });
 
-        it("should ignore if the interaction is not the create button", async () => {
+        it("should ignore if the interaction does not come from the 'Create' button", async () => {
             const data = createMockMessageComponentInteraction({
                 component_type: ComponentType.Button,
                 custom_id: ManageProfileButton.Edit
@@ -102,7 +102,7 @@ describe("Create Profile (InteractionCreate) Event", () => {
             expect(settingsSpy).not.toHaveBeenCalled();
         });
 
-        it("should show an error message if the profiles are disabled in the guild", async () => {
+        it("should show an error message if the module is disabled in the guild", async () => {
             settings.enabled = false;
 
             const data = createMockMessageComponentInteraction({
@@ -120,7 +120,7 @@ describe("Create Profile (InteractionCreate) Event", () => {
             });
         });
 
-        it("should show an error message if the guild has not set a channel for profiles", async () => {
+        it("should show an error message if the guild has not configured a channel for profiles", async () => {
             settings.channelID = null;
 
             const data = createMockMessageComponentInteraction({

--- a/apps/barry/tests/modules/marketplace/profiles/events/createProfile.test.ts
+++ b/apps/barry/tests/modules/marketplace/profiles/events/createProfile.test.ts
@@ -1,5 +1,6 @@
+import type { ProfilesSettings } from "@prisma/client";
+
 import { MessageComponentInteraction, PingInteraction } from "@barry/core";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
     createMockMessageComponentInteraction,
     mockChannel,
@@ -7,7 +8,6 @@ import {
 } from "@barry/testing";
 import { ComponentType } from "@discordjs/core";
 import { ProfileEditor } from "../../../../../src/modules/marketplace/dependencies/profiles/editor/ProfileEditor.js";
-import { ProfilesSettings } from "@prisma/client";
 import { createMockApplication } from "../../../../mocks/index.js";
 import { mockProfile } from "../mocks/profile.js";
 

--- a/apps/barry/tests/modules/marketplace/profiles/events/editProfile.test.ts
+++ b/apps/barry/tests/modules/marketplace/profiles/events/editProfile.test.ts
@@ -174,7 +174,7 @@ describe("Edit Profile (InteractionCreate) Event", () => {
             expect(settingsSpy).not.toHaveBeenCalled();
         });
 
-        it("should ignore if the interaction is not the edit button", async () => {
+        it("should ignore if the interaction does not come from the 'Edit' button", async () => {
             const settingsSpy = vi.spyOn(event.module.profilesSettings, "get");
             interaction.data.customID = ManageProfileButton.Create;
 
@@ -183,7 +183,7 @@ describe("Edit Profile (InteractionCreate) Event", () => {
             expect(settingsSpy).not.toHaveBeenCalled();
         });
 
-        it("should show an error message if the profiles are disabled in the guild", async () => {
+        it("should show an error message if the module is disabled in the guild", async () => {
             const createSpy = vi.spyOn(interaction, "createMessage");
             settings.enabled = false;
 
@@ -196,7 +196,7 @@ describe("Edit Profile (InteractionCreate) Event", () => {
             });
         });
 
-        it("should show an error message if the guild has not set a channel for profiles", async () => {
+        it("should show an error message if the guild has not configured a channel for profiles", async () => {
             const createSpy = vi.spyOn(interaction, "createMessage");
             settings.channelID = null;
 

--- a/apps/barry/tests/modules/marketplace/profiles/events/editProfile.test.ts
+++ b/apps/barry/tests/modules/marketplace/profiles/events/editProfile.test.ts
@@ -1,13 +1,12 @@
-import { APIChannel, ComponentType, MessageFlags } from "@discordjs/core";
+import { type APIChannel, ComponentType, MessageFlags } from "@discordjs/core";
+import { type ProfilesSettings, ProfileCreationStatus } from "@prisma/client";
+
 import { MessageComponentInteraction, PingInteraction } from "@barry/core";
-import { ProfileCreationStatus, ProfilesSettings } from "@prisma/client";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
     createMockMessageComponentInteraction,
     mockChannel,
     mockPingInteraction
 } from "@barry/testing";
-
 import { ProfileEditor } from "../../../../../src/modules/marketplace/dependencies/profiles/editor/ProfileEditor.js";
 import { createMockApplication } from "../../../../mocks/index.js";
 import { mockProfile } from "../mocks/profile.js";

--- a/apps/barry/tests/modules/marketplace/profiles/events/editProfile.test.ts
+++ b/apps/barry/tests/modules/marketplace/profiles/events/editProfile.test.ts
@@ -134,7 +134,7 @@ describe("Edit Profile (InteractionCreate) Event", () => {
         });
 
         it("should prompt the user if they'd like to finish their profile if they haven't yet", async () => {
-            vi.spyOn(event.module.profiles, "get").mockResolvedValue({ ...mockProfile, creationStatus: ProfileCreationStatus.Profile });
+            vi.spyOn(event.module.profiles, "get").mockResolvedValue({ ...mockProfile, creationStatus: ProfileCreationStatus.Contact });
             const createSpy = vi.spyOn(interaction, "createMessage");
 
             await event.execute(interaction);

--- a/apps/barry/tests/modules/marketplace/profiles/events/postProfile.test.ts
+++ b/apps/barry/tests/modules/marketplace/profiles/events/postProfile.test.ts
@@ -1,17 +1,16 @@
+import { type ProfilesSettings, ProfileCreationStatus } from "@prisma/client";
+import type { ProfileWithMessages } from "../../../../../src/modules/marketplace/dependencies/profiles/database.js";
+
 import { ComponentType, MessageFlags } from "@discordjs/core";
 import { MessageComponentInteraction, PingInteraction } from "@barry/core";
-import { ProfileCreationStatus, ProfilesSettings } from "@prisma/client";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
     createMockMessageComponentInteraction,
     mockChannel,
     mockPingInteraction,
     mockUser
 } from "@barry/testing";
-
-import { ProfileWithMessages } from "../../../../../src/modules/marketplace/dependencies/profiles/database.js";
-import { mockProfile } from "../mocks/profile.js";
 import { createMockApplication } from "../../../../mocks/index.js";
+import { mockProfile } from "../mocks/profile.js";
 
 import ProfilesModule, { ManageProfileButton } from "../../../../../src/modules/marketplace/dependencies/profiles/index.js";
 import PostProfileEvent from "../../../../../src/modules/marketplace/dependencies/profiles/events/postProfile.js";

--- a/apps/barry/tests/modules/marketplace/profiles/events/postProfile.test.ts
+++ b/apps/barry/tests/modules/marketplace/profiles/events/postProfile.test.ts
@@ -135,7 +135,7 @@ describe("Post Profile (InteractionCreate) Event", () => {
             expect(settingsSpy).not.toHaveBeenCalled();
         });
 
-        it("should ignore if the interaction is not the post button", async () => {
+        it("should ignore if the interaction does not come from the 'Post' button", async () => {
             const data = createMockMessageComponentInteraction({
                 component_type: ComponentType.Button,
                 custom_id: ManageProfileButton.Edit
@@ -150,7 +150,7 @@ describe("Post Profile (InteractionCreate) Event", () => {
             expect(settingsSpy).not.toHaveBeenCalled();
         });
 
-        it("should show an error message if the profiles are disabled in the guild", async () => {
+        it("should show an error message if the module is disabled in the guild", async () => {
             settings.enabled = false;
 
             vi.spyOn(event.module.profiles, "getWithMessages").mockResolvedValue(profile);
@@ -172,7 +172,7 @@ describe("Post Profile (InteractionCreate) Event", () => {
             });
         });
 
-        it("should show an error message if the guild has not set a channel for profiles", async () => {
+        it("should show an error message if the guild has not configured a channel for profiles", async () => {
             settings.channelID = null;
 
             vi.spyOn(event.module.profiles, "getWithMessages").mockResolvedValue(profile);

--- a/apps/barry/tests/modules/marketplace/profiles/mocks/profile.ts
+++ b/apps/barry/tests/modules/marketplace/profiles/mocks/profile.ts
@@ -1,4 +1,4 @@
-import { Profile } from "@prisma/client";
+import type { Profile } from "@prisma/client";
 import { ProfileAvailability } from "../../../../../src/modules/marketplace/dependencies/profiles/editor/availability.js";
 import { mockUser } from "@barry/testing";
 

--- a/apps/barry/tests/modules/marketplace/requests/database.test.ts
+++ b/apps/barry/tests/modules/marketplace/requests/database.test.ts
@@ -1,10 +1,9 @@
-import { Prisma, RequestStatus, RequestsSettings } from "@prisma/client";
+import { type RequestsSettings, Prisma, RequestStatus } from "@prisma/client";
 import {
     RequestMessageRepository,
     RequestRepository,
     RequestsSettingsRepository
 } from "../../../../src/modules/marketplace/dependencies/requests/database.js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { mockChannel } from "@barry/testing";
 import { mockRequest } from "./mocks/request.js";

--- a/apps/barry/tests/modules/marketplace/requests/editor/RequestEditor.test.ts
+++ b/apps/barry/tests/modules/marketplace/requests/editor/RequestEditor.test.ts
@@ -6,7 +6,6 @@ import {
     ModalSubmitInteraction,
     UpdatableInteraction
 } from "@barry/core";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
     createMockMessageComponentInteraction,
     createMockModalSubmitInteraction,

--- a/apps/barry/tests/modules/marketplace/requests/editor/functions/content.test.ts
+++ b/apps/barry/tests/modules/marketplace/requests/editor/functions/content.test.ts
@@ -1,8 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { getEditContactContent, getEditRequestContent, getRequestContent } from "../../../../../../src/modules/marketplace/dependencies/requests/editor/functions/content.js";
+import { type RequestsSettings, RequestStatus } from "@prisma/client";
+
 import { ComponentType, TextInputStyle } from "@discordjs/core";
+import {
+    getEditContactContent,
+    getEditRequestContent,
+    getRequestContent
+} from "../../../../../../src/modules/marketplace/dependencies/requests/editor/functions/content.js";
 import { mockRequest } from "../../mocks/request.js";
-import { RequestStatus, RequestsSettings } from "@prisma/client";
 import { mockUser } from "@barry/testing";
 
 describe("Content", () => {

--- a/apps/barry/tests/modules/marketplace/requests/events/contactRequest.test.ts
+++ b/apps/barry/tests/modules/marketplace/requests/events/contactRequest.test.ts
@@ -1,6 +1,5 @@
 import { ComponentType, MessageFlags } from "@discordjs/core";
 import { MessageComponentInteraction, PingInteraction } from "@barry/core";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMockMessageComponentInteraction, mockPingInteraction } from "@barry/testing";
 
 import { createMockApplication } from "../../../../mocks/index.js";

--- a/apps/barry/tests/modules/marketplace/requests/events/createRequest.test.ts
+++ b/apps/barry/tests/modules/marketplace/requests/events/createRequest.test.ts
@@ -1,16 +1,16 @@
+import type { RequestsSettings } from "@prisma/client";
+
 import { ComponentType, MessageFlags } from "@discordjs/core";
 import { MessageComponentInteraction, PingInteraction } from "@barry/core";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMockMessageComponentInteraction, mockPingInteraction } from "@barry/testing";
 
 import { RequestEditor } from "../../../../../src/modules/marketplace/dependencies/requests/editor/RequestEditor.js";
-import { RequestsSettings } from "@prisma/client";
 import { createMockApplication } from "../../../../mocks/index.js";
 import { mockRequest } from "../mocks/request.js";
+import { timeoutContent } from "../../../../../src/modules/marketplace/constants.js";
 
 import RequestsModule, { ManageRequestButton } from "../../../../../src/modules/marketplace/dependencies/requests/index.js";
 import CreateRequestEvent from "../../../../../src/modules/marketplace/dependencies/requests/events/createRequest.js";
-import { timeoutContent } from "../../../../../src/modules/marketplace/constants.js";
 
 describe("Create Request (InteractionCreate) Event", () => {
     let event: CreateRequestEvent;

--- a/apps/barry/tests/modules/marketplace/requests/events/createRequest.test.ts
+++ b/apps/barry/tests/modules/marketplace/requests/events/createRequest.test.ts
@@ -123,7 +123,7 @@ describe("Create Request (InteractionCreate) Event", () => {
             });
         });
 
-        it("should show an error message if the guild has not set a channel for requests", async () => {
+        it("should show an error message if the guild has not configured a channel for requests", async () => {
             settings.channelID = null;
 
             vi.spyOn(event.module.requests, "getDraft").mockResolvedValue(null);

--- a/apps/barry/tests/modules/marketplace/requests/events/editRequest.test.ts
+++ b/apps/barry/tests/modules/marketplace/requests/events/editRequest.test.ts
@@ -1,7 +1,7 @@
+import { type RequestsSettings, RequestStatus } from "@prisma/client";
+
 import { ButtonStyle, ComponentType, MessageFlags } from "@discordjs/core";
 import { MessageComponentInteraction, PingInteraction } from "@barry/core";
-import { RequestStatus, RequestsSettings } from "@prisma/client";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
     createMockMessageComponentInteraction,
     mockChannel,

--- a/apps/barry/tests/modules/marketplace/requests/events/postRequest.test.ts
+++ b/apps/barry/tests/modules/marketplace/requests/events/postRequest.test.ts
@@ -1,9 +1,8 @@
+import type { RequestsSettings } from "@prisma/client";
+
 import { ButtonStyle, ComponentType, MessageFlags } from "@discordjs/core";
 import { MessageComponentInteraction, PingInteraction } from "@barry/core";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMockMessageComponentInteraction, mockPingInteraction } from "@barry/testing";
-
-import { RequestsSettings } from "@prisma/client";
 import { createMockApplication } from "../../../../mocks/application.js";
 import { mockRequest } from "../mocks/request.js";
 import { timeoutContent } from "../../../../../src/modules/marketplace/constants.js";

--- a/apps/barry/tests/modules/marketplace/requests/index.test.ts
+++ b/apps/barry/tests/modules/marketplace/requests/index.test.ts
@@ -1,18 +1,20 @@
+import type { RequestsSettings } from "@prisma/client";
+
 import { ButtonStyle, ComponentType } from "@discordjs/core";
 import {
     RequestMessageRepository,
     RequestRepository,
     RequestsSettingsRepository
 } from "../../../../src/modules/marketplace/dependencies/requests/database.js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mockUser, mockMessage } from "@barry/testing";
-
-import { RequestsSettings } from "@prisma/client";
 import { createMockApplication } from "../../../mocks/application.js";
 import { getRequestContent } from "../../../../src/modules/marketplace/dependencies/requests/editor/functions/content.js";
 import { mockRequest } from "./mocks/request.js";
 
-import RequestsModule, { ManageRequestButton, RequestActionButton } from "../../../../src/modules/marketplace/dependencies/requests/index.js";
+import RequestsModule, {
+    ManageRequestButton,
+    RequestActionButton
+} from "../../../../src/modules/marketplace/dependencies/requests/index.js";
 
 describe("RequestsModule", () => {
     let module: RequestsModule;

--- a/apps/barry/tests/modules/marketplace/requests/mocks/request.ts
+++ b/apps/barry/tests/modules/marketplace/requests/mocks/request.ts
@@ -1,5 +1,5 @@
+import type { RequestWithAttachments } from "../../../../../src/modules/marketplace/dependencies/requests/database.js";
 import { RequestStatus } from "@prisma/client";
-import { RequestWithAttachments } from "../../../../../src/modules/marketplace/dependencies/requests/database.js";
 import { mockUser } from "@barry/testing";
 
 export const mockRequest: RequestWithAttachments = {

--- a/apps/barry/tests/modules/marketplace/utils.test.ts
+++ b/apps/barry/tests/modules/marketplace/utils.test.ts
@@ -1,10 +1,14 @@
-import { createMockModalSubmitInteraction } from "@barry/testing";
-import { capitalizeEachSentence, capitalizeEachWord, displayContact } from "../../../src/modules/marketplace/utils.js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { UpdatableInteraction } from "@barry/core";
-import { mockProfile } from "./profiles/mocks/profile.js";
+import {
+    capitalizeEachSentence,
+    capitalizeEachWord,
+    displayContact
+} from "../../../src/modules/marketplace/utils.js";
+
 import { MessageFlags } from "@discordjs/core";
+import { UpdatableInteraction } from "@barry/core";
 import { createMockApplication } from "../../mocks/application.js";
+import { createMockModalSubmitInteraction } from "@barry/testing";
+import { mockProfile } from "./profiles/mocks/profile.js";
 
 describe("Utils", () => {
     describe("capitalizeEachSentence", () => {

--- a/apps/barry/tests/utils/loadFolder.test.ts
+++ b/apps/barry/tests/utils/loadFolder.test.ts
@@ -1,31 +1,17 @@
 import type { Dirent } from "node:fs";
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { loadCommands, loadEvents, loadFolder, loadModules } from "../../src/utils/index.js";
-import { BaseCommand, Event, Module, SlashCommand } from "@barry/core";
-
-import fs from "node:fs/promises";
-
+import { MockCommand, MockEvent, MockModule } from "../mocks/index.js";
+import {
+    loadCommands,
+    loadEvents,
+    loadFolder,
+    loadModules
+} from "../../src/utils/index.js";
+import { BaseCommand } from "@barry/core";
 import { fileURLToPath } from "node:url";
 import { resolve } from "node:path";
 
-class MockCommand extends SlashCommand {
-    async execute(): Promise<void> {
-        // empty.
-    }
-}
-
-class MockEvent extends Event {
-    async execute(): Promise<void> {
-        // empty.
-    }
-}
-
-class MockModule extends Module {
-    isEnabled(): boolean {
-        return true;
-    }
-}
+import fs from "node:fs/promises";
 
 vi.mock("node:fs/promises");
 

--- a/apps/barry/tests/utils/pagination.test.ts
+++ b/apps/barry/tests/utils/pagination.test.ts
@@ -1,12 +1,15 @@
 import {
+    type IndexBasedPaginationOptions,
+    type ValueBasedPaginationOptions,
+    PaginationMessage
+} from "../../src/utils/index.js";
+import {
     type ReplyableInteraction,
     ApplicationCommandInteraction,
     MessageComponentInteraction
 } from "@barry/core";
-import { IndexBasedPaginationOptions, PaginationMessage, ValueBasedPaginationOptions } from "../../src/utils/index.js";
 
 import { ComponentType, MessageFlags } from "@discordjs/core";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
     createMockApplicationCommandInteraction,
     createMockMessageComponentInteraction,

--- a/apps/barry/tests/utils/utils.test.ts
+++ b/apps/barry/tests/utils/utils.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from "vitest";
 import { capitalize } from "../../src/utils/index.js";
 
 describe("utils", () => {

--- a/packages/core/tests/Client.test.ts
+++ b/packages/core/tests/Client.test.ts
@@ -15,13 +15,11 @@ import {
     GatewayOpcodes
 } from "@discordjs/core";
 
-import { beforeEach, describe, it, expect, vi } from "vitest";
 import {
     MockGateway,
     MockServer,
     createMockModule
 } from "./mocks/index.js";
-
 import { mockPingInteraction } from "@barry/testing";
 import { Logger } from "@barry/logger";
 

--- a/packages/core/tests/Server.test.ts
+++ b/packages/core/tests/Server.test.ts
@@ -1,10 +1,8 @@
 import { type HeadersInit, fetch } from "undici";
 import { type Server, FastifyServer, StatusCodes } from "../src/index.js";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-
-import nacl from "tweetnacl";
 import { File } from "node:buffer";
+import nacl from "tweetnacl";
 
 const SERVER_HOST = "localhost";
 const SERVER_PORT = 3000;

--- a/packages/core/tests/commands/BaseCommand.test.ts
+++ b/packages/core/tests/commands/BaseCommand.test.ts
@@ -1,7 +1,6 @@
 import { type API, ApplicationCommandType } from "@discordjs/core";
 import { type Module, Client } from "../../src/index.js";
 
-import { beforeEach, describe, expect, it } from "vitest";
 import { MockBaseCommand, MockModule, baseCommandOptions } from "../mocks/index.js";
 
 describe("BaseCommand", () => {

--- a/packages/core/tests/commands/MessageCommand.test.ts
+++ b/packages/core/tests/commands/MessageCommand.test.ts
@@ -1,7 +1,6 @@
 import { type API, ApplicationCommandType } from "@discordjs/core";
 import { type Module, Client } from "../../src/index.js";
 
-import { beforeEach, describe, expect, it } from "vitest";
 import { MockMessageCommand, MockModule } from "../mocks/index.js";
 
 describe("MessageCommand", () => {

--- a/packages/core/tests/commands/SlashCommand.test.ts
+++ b/packages/core/tests/commands/SlashCommand.test.ts
@@ -5,7 +5,6 @@ import {
 } from "@discordjs/core";
 import { type Module, Client } from "../../src/index.js";
 
-import { beforeEach, describe, expect, it } from "vitest";
 import {
     MockModule,
     MockSlashCommand,

--- a/packages/core/tests/commands/SlashCommandOptionBuilder.test.ts
+++ b/packages/core/tests/commands/SlashCommandOptionBuilder.test.ts
@@ -4,7 +4,6 @@ import {
     SlashCommandOptionBuilder
 } from "../../src/index.js";
 
-import { describe, expect, it } from "vitest";
 import { ApplicationCommandOptionType, ChannelType } from "@discordjs/core";
 import { createMockAutocompleteInteraction } from "@barry/testing";
 

--- a/packages/core/tests/commands/UserCommand.test.ts
+++ b/packages/core/tests/commands/UserCommand.test.ts
@@ -1,7 +1,6 @@
 import { type API, ApplicationCommandType } from "@discordjs/core";
 import { type Module, Client } from "../../src/index.js";
 
-import { beforeEach, describe, expect, it } from "vitest";
 import { MockModule, MockUserCommand } from "../mocks/index.js";
 
 describe("UserCommand", () => {

--- a/packages/core/tests/events/Event.test.ts
+++ b/packages/core/tests/events/Event.test.ts
@@ -1,7 +1,6 @@
 import { type API, GatewayDispatchEvents } from "@discordjs/core";
 import { type Module, Client } from "../../src/index.js";
 
-import { beforeEach, describe, expect, it } from "vitest";
 import { Event } from "../../src/events/index.js";
 import { MockModule } from "../mocks/index.js";
 

--- a/packages/core/tests/interactions/ApplicationCommandInteraction.test.ts
+++ b/packages/core/tests/interactions/ApplicationCommandInteraction.test.ts
@@ -13,7 +13,6 @@ import {
     MessageApplicationCommandInteractionData,
     UserApplicationCommandInteractionData
 } from "../../src/index.js";
-import { beforeEach, describe, expect, it } from "vitest";
 import {
     createMockApplicationCommandInteraction,
     mockAttachment,

--- a/packages/core/tests/interactions/AutocompleteInteraction.test.ts
+++ b/packages/core/tests/interactions/AutocompleteInteraction.test.ts
@@ -4,7 +4,6 @@ import {
     InteractionResponseType
 } from "@discordjs/core";
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AutocompleteInteraction, Client } from "../../src/index.js";
 import { createMockAutocompleteInteraction } from "@barry/testing";
 

--- a/packages/core/tests/interactions/Interaction.test.ts
+++ b/packages/core/tests/interactions/Interaction.test.ts
@@ -10,7 +10,6 @@ import {
     ModalSubmitInteraction,
     PingInteraction
 } from "../../src/index.js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
     createMockApplicationCommandInteraction,
     createMockAutocompleteInteraction,

--- a/packages/core/tests/interactions/MessageComponentInteraction.test.ts
+++ b/packages/core/tests/interactions/MessageComponentInteraction.test.ts
@@ -1,6 +1,5 @@
 import { type API, InteractionType, ComponentType } from "@discordjs/core";
 
-import { beforeEach, describe, expect, it } from "vitest";
 import {
     Client,
     MessageButtonInteractionData,

--- a/packages/core/tests/interactions/ModalSubmitInteraction.test.ts
+++ b/packages/core/tests/interactions/ModalSubmitInteraction.test.ts
@@ -1,6 +1,5 @@
 import { type API, InteractionType, ComponentType } from "@discordjs/core";
 
-import { beforeEach, describe, expect, it } from "vitest";
 import { Client, ModalSubmitInteraction } from "../../src/index.js";
 import { createMockModalSubmitInteraction } from "@barry/testing";
 

--- a/packages/core/tests/interactions/PingInteraction.test.ts
+++ b/packages/core/tests/interactions/PingInteraction.test.ts
@@ -1,6 +1,5 @@
 import { type API, InteractionResponseType, InteractionType } from "@discordjs/core";
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Client, PingInteraction } from "../../src/index.js";
 import { mockPingInteraction } from "@barry/testing";
 

--- a/packages/core/tests/interactions/ReplyableInteraction.test.ts
+++ b/packages/core/tests/interactions/ReplyableInteraction.test.ts
@@ -1,7 +1,6 @@
 import { type API, GatewayDispatchEvents, InteractionResponseType } from "@discordjs/core";
 
 import { Client, InteractionFactory, ReplyableInteraction } from "../../src/index.js";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
     createMockApplicationCommandInteraction,
     createMockMessageComponentInteraction,

--- a/packages/core/tests/interactions/UpdatableInteraction.test.ts
+++ b/packages/core/tests/interactions/UpdatableInteraction.test.ts
@@ -1,6 +1,5 @@
 import { type API, InteractionResponseType } from "@discordjs/core";
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Client, UpdatableInteraction } from "../../src/index.js";
 import { createMockModalSubmitInteraction } from "@barry/testing";
 

--- a/packages/core/tests/modules/Module.test.ts
+++ b/packages/core/tests/modules/Module.test.ts
@@ -6,7 +6,6 @@ import {
     Event
 } from "../../src/index.js";
 
-import { beforeEach, describe, expect, it } from "vitest";
 import { MockSlashCommandBar, MockSlashCommandFoo } from "../mocks/commands.js";
 import { MockModule, mockModuleOptions } from "../mocks/index.js";
 

--- a/packages/core/tests/services/ModuleService.test.ts
+++ b/packages/core/tests/services/ModuleService.test.ts
@@ -1,6 +1,5 @@
 import { type API } from "@discordjs/core";
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Client, ModuleService } from "../../src/index.js";
 import { MockModule } from "../mocks/index.js";
 

--- a/packages/core/tests/services/commands/CommandService.test.ts
+++ b/packages/core/tests/services/commands/CommandService.test.ts
@@ -11,7 +11,6 @@ import {
     ApplicationCommandType
 } from "@discordjs/core";
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
     MockModule,
     MockMessageCommand,

--- a/packages/core/tests/services/commands/CooldownManager.test.ts
+++ b/packages/core/tests/services/commands/CooldownManager.test.ts
@@ -1,5 +1,4 @@
 import { type CooldownManager, MapCooldownManager } from "../../../src/index.js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("MapCooldownManager", () => {
     const key = "cooldown";

--- a/packages/core/tests/services/interactions/ApplicationCommandInteractionHandler.test.ts
+++ b/packages/core/tests/services/interactions/ApplicationCommandInteractionHandler.test.ts
@@ -11,7 +11,6 @@ import {
     Client
 } from "../../../src/index.js";
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
     MockMessageCommand,
     MockSlashCommand,

--- a/packages/core/tests/services/interactions/AutocompleteInteractionHandler.test.ts
+++ b/packages/core/tests/services/interactions/AutocompleteInteractionHandler.test.ts
@@ -12,7 +12,6 @@ import {
     SlashCommandOptionBuilder
 } from "../../../src/index.js";
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
     MockMessageCommand,
     MockSlashCommand,

--- a/packages/core/tests/services/interactions/InteractionService.test.ts
+++ b/packages/core/tests/services/interactions/InteractionService.test.ts
@@ -1,6 +1,5 @@
 import { type API, InteractionType } from "@discordjs/core";
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
     ApplicationCommandInteraction,
     ApplicationCommandInteractionHandler,

--- a/packages/core/tests/services/interactions/PingInteractionHandler.test.ts
+++ b/packages/core/tests/services/interactions/PingInteractionHandler.test.ts
@@ -1,6 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { PingInteraction, PingInteractionHandler } from "../../../src/index.js";
-
 import { InteractionResponseType } from "@discordjs/core";
 import { mockPingInteraction } from "@barry/testing";
 

--- a/packages/core/tests/utils/FormData.test.ts
+++ b/packages/core/tests/utils/FormData.test.ts
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, it } from "vitest";
 import { FormData } from "../../src/index.js";
 
 describe("FormData", () => {

--- a/packages/core/tests/utils/utils.test.ts
+++ b/packages/core/tests/utils/utils.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from "vitest";
 import {
     getAvatarURL,
     getCreatedAt,

--- a/packages/logger/tests/Logger.test.ts
+++ b/packages/logger/tests/Logger.test.ts
@@ -1,11 +1,3 @@
-import {
-    type SpyInstance,
-    beforeEach,
-    describe,
-    expect,
-    it,
-    vi
-} from "vitest";
 import { Logger, LogSeverity } from "../src/index.js";
 
 import * as Sentry from "@sentry/node";
@@ -18,11 +10,10 @@ vi.mock("@sentry/node", () => ({
 }));
 
 describe("Logger", () => {
-    let consoleSpy: SpyInstance;
-
     beforeEach(() => {
         vi.restoreAllMocks();
-        consoleSpy = vi.spyOn(console, "log").mockImplementation(() => void 0);
+
+        console.log = vi.fn();
     });
 
     describe("debug", () => {
@@ -32,9 +23,9 @@ describe("Logger", () => {
 
             logger.debug(message);
 
-            expect(consoleSpy).toHaveBeenCalledOnce();
-            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("DEBUG"));
-            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(message));
+            expect(console.log).toHaveBeenCalledOnce();
+            expect(console.log).toHaveBeenCalledWith(expect.stringContaining("DEBUG"));
+            expect(console.log).toHaveBeenCalledWith(expect.stringContaining(message));
         });
     });
 
@@ -45,9 +36,9 @@ describe("Logger", () => {
 
             logger.error(message);
 
-            expect(consoleSpy).toHaveBeenCalledOnce();
-            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("ERROR"));
-            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(message));
+            expect(console.log).toHaveBeenCalledOnce();
+            expect(console.log).toHaveBeenCalledWith(expect.stringContaining("ERROR"));
+            expect(console.log).toHaveBeenCalledWith(expect.stringContaining(message));
         });
     });
 
@@ -58,9 +49,9 @@ describe("Logger", () => {
 
             logger.fatal(message);
 
-            expect(consoleSpy).toHaveBeenCalledOnce();
-            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("FATAL"));
-            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(message));
+            expect(console.log).toHaveBeenCalledOnce();
+            expect(console.log).toHaveBeenCalledWith(expect.stringContaining("FATAL"));
+            expect(console.log).toHaveBeenCalledWith(expect.stringContaining(message));
         });
     });
 
@@ -71,9 +62,9 @@ describe("Logger", () => {
 
             logger.info(message);
 
-            expect(consoleSpy).toHaveBeenCalledOnce();
-            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("INFO"));
-            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(message));
+            expect(console.log).toHaveBeenCalledOnce();
+            expect(console.log).toHaveBeenCalledWith(expect.stringContaining("INFO"));
+            expect(console.log).toHaveBeenCalledWith(expect.stringContaining(message));
         });
     });
 
@@ -84,9 +75,9 @@ describe("Logger", () => {
 
             logger.trace(message);
 
-            expect(consoleSpy).toHaveBeenCalledOnce();
-            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("TRACE"));
-            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(message));
+            expect(console.log).toHaveBeenCalledOnce();
+            expect(console.log).toHaveBeenCalledWith(expect.stringContaining("TRACE"));
+            expect(console.log).toHaveBeenCalledWith(expect.stringContaining(message));
         });
     });
 
@@ -97,9 +88,9 @@ describe("Logger", () => {
 
             logger.warn(message);
 
-            expect(consoleSpy).toHaveBeenCalledOnce();
-            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("WARN"));
-            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(message));
+            expect(console.log).toHaveBeenCalledOnce();
+            expect(console.log).toHaveBeenCalledWith(expect.stringContaining("WARN"));
+            expect(console.log).toHaveBeenCalledWith(expect.stringContaining(message));
         });
     });
 
@@ -111,9 +102,9 @@ describe("Logger", () => {
 
                 logger.warn(message);
 
-                expect(consoleSpy).toHaveBeenCalledOnce();
-                expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("WARN"));
-                expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(message));
+                expect(console.log).toHaveBeenCalledOnce();
+                expect(console.log).toHaveBeenCalledWith(expect.stringContaining("WARN"));
+                expect(console.log).toHaveBeenCalledWith(expect.stringContaining(message));
             });
 
             it("should log a message when the severity is higher than minSeverity", () => {
@@ -122,9 +113,9 @@ describe("Logger", () => {
 
                 logger.warn(message);
 
-                expect(consoleSpy).toHaveBeenCalledOnce();
-                expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("WARN"));
-                expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(message));
+                expect(console.log).toHaveBeenCalledOnce();
+                expect(console.log).toHaveBeenCalledWith(expect.stringContaining("WARN"));
+                expect(console.log).toHaveBeenCalledWith(expect.stringContaining(message));
             });
 
             it("should not log a message when the severity is lower than minSeverity", () => {
@@ -133,7 +124,7 @@ describe("Logger", () => {
 
                 logger.warn(message);
 
-                expect(consoleSpy).not.toHaveBeenCalled();
+                expect(console.log).not.toHaveBeenCalled();
             });
 
             it("should set minSeverity to 'INFO' in a production environment", () => {
@@ -142,7 +133,7 @@ describe("Logger", () => {
 
                 logger.debug(message);
 
-                expect(consoleSpy).not.toHaveBeenCalled();
+                expect(console.log).not.toHaveBeenCalled();
             });
 
             it("should set minSeverity to 'TRACE' in a non-production environment", () => {
@@ -151,7 +142,7 @@ describe("Logger", () => {
 
                 logger.trace(message);
 
-                expect(consoleSpy).toHaveBeenCalled();
+                expect(console.log).toHaveBeenCalled();
             });
         });
 
@@ -170,8 +161,8 @@ describe("Logger", () => {
 
                 logger.info(message);
 
-                expect(consoleSpy).toHaveBeenCalledOnce();
-                expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(date));
+                expect(console.log).toHaveBeenCalledOnce();
+                expect(console.log).toHaveBeenCalledWith(expect.stringContaining(date));
             });
 
             it("should hide the date if 'showDate' is false", () => {
@@ -181,8 +172,8 @@ describe("Logger", () => {
 
                 logger.info(message);
 
-                expect(consoleSpy).toHaveBeenCalledOnce();
-                expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining(date));
+                expect(console.log).toHaveBeenCalledOnce();
+                expect(console.log).not.toHaveBeenCalledWith(expect.stringContaining(date));
             });
 
             it("should show the date by default in a production environment", () => {
@@ -192,8 +183,8 @@ describe("Logger", () => {
 
                 logger.info(message);
 
-                expect(consoleSpy).toHaveBeenCalledOnce();
-                expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(date));
+                expect(console.log).toHaveBeenCalledOnce();
+                expect(console.log).toHaveBeenCalledWith(expect.stringContaining(date));
             });
 
             it("should hide the date by default in a non-production environment", () => {
@@ -203,8 +194,8 @@ describe("Logger", () => {
 
                 logger.info(message);
 
-                expect(consoleSpy).toHaveBeenCalledOnce();
-                expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining(date));
+                expect(console.log).toHaveBeenCalledOnce();
+                expect(console.log).not.toHaveBeenCalledWith(expect.stringContaining(date));
             });
         });
 
@@ -221,8 +212,8 @@ describe("Logger", () => {
 
                 logger.info("Hello %s", "World");
 
-                expect(consoleSpy).toHaveBeenCalledOnce();
-                expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Hello World"));
+                expect(console.log).toHaveBeenCalledOnce();
+                expect(console.log).toHaveBeenCalledWith(expect.stringContaining("Hello World"));
             });
 
             it("should format log messages with error objects", () => {
@@ -234,10 +225,10 @@ describe("Logger", () => {
 
                 logger.error(message, error);
 
-                expect(consoleSpy).toHaveBeenCalledOnce();
-                expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(message));
-                expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(error.message));
-                expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(stack));
+                expect(console.log).toHaveBeenCalledOnce();
+                expect(console.log).toHaveBeenCalledWith(expect.stringContaining(message));
+                expect(console.log).toHaveBeenCalledWith(expect.stringContaining(error.message));
+                expect(console.log).toHaveBeenCalledWith(expect.stringContaining(stack));
             });
 
             it("should ignore the error stack if undefined", () => {
@@ -250,10 +241,10 @@ describe("Logger", () => {
                 error.stack = undefined;
                 logger.error(message, error);
 
-                expect(consoleSpy).toHaveBeenCalledOnce();
-                expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(message));
-                expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(error.message));
-                expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining(stack));
+                expect(console.log).toHaveBeenCalledOnce();
+                expect(console.log).toHaveBeenCalledWith(expect.stringContaining(message));
+                expect(console.log).toHaveBeenCalledWith(expect.stringContaining(error.message));
+                expect(console.log).not.toHaveBeenCalledWith(expect.stringContaining(stack));
             });
         });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
         "skipLibCheck": true,
         "strict": true,
         "target": "ES2022",
+        "types": ["vitest/globals"],
         "verbatimModuleSyntax": true
     },
     "exclude": ["node_modules"]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
             provider: "v8",
             reporter: ["text", "lcov", "cobertura"]
         },
+        globals: true,
         passWithNoTests: true
     }
 });


### PR DESCRIPTION
- Improves consistency in code and tests.
- Makes `vitest` global
- Add settings to `ProfileEditor` directly, removes the need for loading them again later on.