### PR TITLE
feat: implement warn command

### DIFF
--- a/apps/barry/prisma/schema.prisma
+++ b/apps/barry/prisma/schema.prisma
@@ -153,3 +153,53 @@ model RequestsSettings {
 
   @@map("requests_settings")
 }
+
+// Moderation
+enum CaseType {
+  Note    @map("NOTE")
+  Warn    @map("WARN")
+  Mute    @map("MUTE")
+  Kick    @map("KICK")
+  Ban     @map("BAN")
+  Unmute  @map("UNMUTE")
+  Unban   @map("UNBAN")
+}
+
+model Case {
+  id        Int
+  guildID   String     @map("guild_id")
+  creatorID String     @map("creator_id")
+  notes     CaseNote[]
+  type      CaseType
+  userID    String     @map("user_id")
+  createdAt DateTime   @default(now()) @map("created_at")
+
+  @@id([guildID, id])
+  @@index([guildID, userID])
+  @@index([guildID, creatorID])
+  @@index([guildID, type])
+  @@map("cases")
+}
+
+model CaseNote {
+  id        Int
+  caseID    Int      @map("case_id")
+  guildID   String   @map("guild_id")
+  case      Case     @relation(references: [guildID, id], fields: [guildID, caseID], onDelete: Cascade)
+  content   String
+  creatorID String   @map("creator_id")
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@id([guildID, caseID, id])
+  @@map("case_notes")
+}
+
+model ModerationSettings {
+  guildID   String  @id @map("guild_id")
+  channelID String? @map("channel_id")
+  dwcDays   Int     @map("dwc_days") @default(7)
+  dwcRoleID String? @map("dwc_role_id")
+  enabled   Boolean @default(false)
+
+  @@map("moderation_settings")
+}

--- a/apps/barry/src/modules/moderation/commands/chatinput/warn/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/warn/index.ts
@@ -1,0 +1,165 @@
+import { type APIUser, PermissionFlagsBits, MessageFlags } from "@discordjs/core";
+import {
+    type ApplicationCommandInteraction,
+    SlashCommand,
+    SlashCommandOptionBuilder
+} from "@barry/core";
+import { type PartialGuildMember, isAboveMember } from "../../../functions/permissions.js";
+import type ModerationModule from "../../../index.js";
+
+import { COMMON_MINOR_REASONS } from "../../../constants.js";
+import { CaseType } from "@prisma/client";
+import { DiscordAPIError } from "@discordjs/rest";
+import config from "../../../../../config.js";
+
+/**
+ * Options for the warn command.
+ */
+export interface WarnOptions {
+    /**
+     * The member to warn.
+     */
+    member: PartialGuildMember;
+
+    /**
+     * The reason for the warning.
+     */
+    reason: string;
+}
+
+/**
+ * Represents a slash command that warns a user.
+ */
+export default class extends SlashCommand<ModerationModule> {
+    /**
+     * Represents the constructor of this slash command.
+     *
+     * @param module The module this command belongs to.
+     */
+    constructor(module: ModerationModule) {
+        super(module, {
+            name: "warn",
+            description: "Warns a user.",
+            defaultMemberPermissions: PermissionFlagsBits.ModerateMembers,
+            guildOnly: true,
+            options: {
+                member: SlashCommandOptionBuilder.member({
+                    description: "The member to warn.",
+                    required: true
+                }),
+                reason: SlashCommandOptionBuilder.string({
+                    description: "The reason for the warning (type to enter a custom reason)",
+                    maximum: 200,
+                    required: true,
+                    autocomplete: (value) => COMMON_MINOR_REASONS
+                        .filter((x) => x.toLowerCase().startsWith(value.toLowerCase()))
+                        .map((x) => ({ name: x, value: x }))
+                })
+            }
+        });
+    }
+
+    /**
+     * Warns the user.
+     *
+     * @param interaction The interaction that triggered the command.
+     * @param options The options for the command.
+     */
+    async execute(interaction: ApplicationCommandInteraction, options: WarnOptions): Promise<void> {
+        if (!interaction.isInvokedInGuild()) {
+            return;
+        }
+
+        if (options.member.user.id === interaction.user.id) {
+            return interaction.createMessage({
+                content: `${config.emotes.error} You cannot warn yourself.`,
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
+        if (options.member.user.id === this.client.applicationID) {
+            return interaction.createMessage({
+                content: `${config.emotes.error} Your attempt to warn me has been classified as a failed comedy show audition.`,
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
+        const guild = await this.client.api.guilds.get(interaction.guildID);
+        if (!isAboveMember(guild, interaction.member, options.member)) {
+            return interaction.createMessage({
+                content: `${config.emotes.error} You cannot warn a member with a higher or equal role to you.`,
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
+        const self = await this.client.api.guilds.getMember(interaction.guildID, this.client.applicationID);
+        if (!isAboveMember(guild, self as PartialGuildMember, options.member)) {
+            return interaction.createMessage({
+                content: `${config.emotes.error} I cannot warn a member with a higher or equal role to me.`,
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
+        const entity = await this.module.cases.create({
+            creatorID: interaction.user.id,
+            guildID: interaction.guildID,
+            note: options.reason,
+            type: CaseType.Warn,
+            userID: options.member.user.id
+        });
+
+        try {
+            const channel = await this.client.api.users.createDM(options.member.user.id);
+            await this.client.api.channels.createMessage(channel.id, {
+                embeds: [{
+                    color: config.defaultColor,
+                    description: `${config.emotes.error} You have been warned in **${guild.name}**`,
+                    fields: [{
+                        name: "**Reason**",
+                        value: options.reason
+                    }]
+                }]
+            });
+        } catch (error: unknown) {
+            if (!(error instanceof DiscordAPIError) || error.code !== 50007) {
+                this.client.logger.error(error);
+            }
+
+            return this.#onSuccess(interaction, entity.id, options.member.user, true);
+        }
+
+        await this.#onSuccess(interaction, entity.id, options.member.user);
+    }
+
+    /**
+     * Sends a success message to the user.
+     *
+     * @param interaction The interaction to reply to.
+     * @param caseID The ID of the case.
+     * @param user The user that has gotten warned.
+     * @param isDisabled Whether the user's DMs are disabled.
+     */
+    async #onSuccess(
+        interaction: ApplicationCommandInteraction,
+        caseID: number,
+        user: APIUser,
+        isDisabled: boolean = false
+    ): Promise<void> {
+        let content = `Successfully warned \`${user.username}\`.`;
+        if (isDisabled) {
+            content += " However, they have disabled their DMs, so I was unable to notify them.";
+        }
+
+        const warnings = await this.module.cases.getByUser(interaction.guildID!, user.id, CaseType.Warn);
+        if (warnings.length === 2) {
+            content += " They already have a warning; please review their previous cases and take action if needed.";
+        } else if (warnings.length > 2) {
+            content += ` They currently have \`${warnings.length - 1}\` warnings; please review their previous cases and take action if needed.`;
+        }
+
+        await interaction.createMessage({
+            content: `${config.emotes.check} Case \`${caseID}\` | ${content}`,
+            flags: MessageFlags.Ephemeral
+        });
+    }
+}

--- a/apps/barry/src/modules/moderation/constants.ts
+++ b/apps/barry/src/modules/moderation/constants.ts
@@ -1,0 +1,26 @@
+export const COMMON_SEVERE_REASONS = [
+    "Suspicious or spam account",
+    "Compromised or hacked account",
+    "Being abusive or disrespectful",
+    "Scamming or wasting a someone's time",
+    "Violating Discord's Terms of Service",
+    "Violating server rules",
+    "Trolling"
+];
+
+export const COMMON_MINOR_REASONS = [
+    "Being abusive or disrespectful",
+    "Spamming",
+    "Trolling",
+    "Self-promoting without permission",
+    "Sending NSFW or obscene content",
+    "Violating server rules"
+];
+
+export const COMMON_DWC_REASONS = [
+    "Not paying for services",
+    "Wasting a someone's time",
+    "Not responding after receiving final product",
+    "Not delivering the work to the client",
+    "Selling work that is not theirs"
+];

--- a/apps/barry/src/modules/moderation/database.ts
+++ b/apps/barry/src/modules/moderation/database.ts
@@ -1,0 +1,362 @@
+import type {
+    Case,
+    CaseNote,
+    CaseType,
+    ModerationSettings,
+    Prisma,
+    PrismaClient
+} from "@prisma/client";
+
+/**
+ * Options for creating a case.
+ */
+export interface CreateCaseOptions {
+    /**
+     * The ID of the user who created the case.
+     */
+    creatorID: string;
+
+    /**
+     * The ID of the guild.
+     */
+    guildID: string;
+
+    /**
+     * The note for the case.
+     */
+    note: string;
+
+    /**
+     * The type of the case.
+     */
+    type: CaseType;
+
+    /**
+     * The ID of the user who the case is for.
+     */
+    userID: string;
+}
+
+/**
+ * Options for creating a case note.
+ */
+export interface CreateCaseNoteOptions {
+    /**
+     * The ID of the case.
+     */
+    caseID: number;
+
+    /**
+     * The content of the note.
+     */
+    content: string;
+
+    /**
+     * The ID of the user who created the note.
+     */
+    creatorID: string;
+
+    /**
+     * The ID of the guild.
+     */
+    guildID: string;
+}
+
+/**
+ * Repository class for managing moderation cases.
+ */
+export class CaseRepository {
+    /**
+     * The Prisma client used to interact with the database.
+     */
+    #prisma: PrismaClient;
+
+    /**
+     * Repository class for managing moderation cases.
+     *
+     * @param prisma The Prisma client used to interact with the database.
+     */
+    constructor(prisma: PrismaClient) {
+        this.#prisma = prisma;
+    }
+
+    /**
+     * Creates a new case.
+     *
+     * @param options The options for the case.
+     * @returns The new case record.
+     */
+    async create(options: CreateCaseOptions): Promise<Case> {
+        const caseID = await this.nextInSequence(options.guildID);
+        return this.#prisma.case.create({
+            data: {
+                creatorID: options.creatorID,
+                guildID: options.guildID,
+                id: caseID,
+                notes: {
+                    create: {
+                        content: options.note,
+                        creatorID: options.creatorID,
+                        id: 1
+                    }
+                },
+                type: options.type,
+                userID: options.userID
+            }
+        });
+    }
+
+    /**
+     * Deletes a case.
+     *
+     * @param guildID The ID of the guild.
+     * @param caseID The ID of the case.
+     * @returns The deleted case record.
+     */
+    async delete(guildID: string, caseID: number): Promise<Case> {
+        return this.#prisma.case.delete({
+            where: {
+                guildID_id: {
+                    guildID: guildID,
+                    id: caseID
+                }
+            }
+        });
+    }
+
+    /**
+     * Retrieves a case by its ID.
+     *
+     * @param guildID The ID of the guild.
+     * @param caseID The ID of the case.
+     * @param withNotes Whether to include the notes.
+     * @returns The case record, or null if not found.
+     */
+    async get(guildID: string, caseID: number, withNotes: boolean = false): Promise<Case | null> {
+        return this.#prisma.case.findUnique({
+            include: { notes: withNotes },
+            where: {
+                guildID_id: {
+                    guildID: guildID,
+                    id: caseID
+                }
+            }
+        });
+    }
+
+    /**
+     * Retrieves all cases for the specified guild.
+     *
+     * @param guildID The ID of the guild.
+     * @param type The type of cases to retrieve.
+     * @returns The found case records.
+     */
+    async getAll(guildID: string, type?: CaseType): Promise<Case[]> {
+        return this.#prisma.case.findMany({
+            where: { guildID, type }
+        });
+    }
+
+    /**
+     * Retrieves all cases for the specified user.
+     *
+     * @param guildID The ID of the guild.
+     * @param userID The ID of the user.
+     * @param type The type of cases to retrieve.
+     * @returns The found case records.
+     */
+    async getByUser(guildID: string, userID: string, type?: CaseType): Promise<Case[]> {
+        return this.#prisma.case.findMany({
+            where: { guildID, type, userID }
+        });
+    }
+
+    /**
+     * Gets the next case ID in the sequence for the specified guild.
+     *
+     * @param guildID The ID of the guild.
+     * @returns The next case ID in the sequence.
+     */
+    async nextInSequence(guildID: string): Promise<number> {
+        return this.#prisma.case
+            .aggregate({
+                where: { guildID },
+                _max: { id: true }
+            })
+            .then(({ _max }) => _max.id !== null ? _max.id + 1 : 1);
+    }
+
+    /**
+     * Updates a case.
+     *
+     * @param guildID The ID of the guild.
+     * @param caseID The ID of the case.
+     * @param options The options for the case.
+     * @returns The updated case record.
+     */
+    async update(guildID: string, caseID: number, options: Prisma.CaseUpdateInput): Promise<Case> {
+        return this.#prisma.case.update({
+            data: options,
+            where: {
+                guildID_id: {
+                    guildID: guildID,
+                    id: caseID
+                }
+            }
+        });
+    }
+}
+
+/**
+ * Repository class for managing case notes.
+ */
+export class CaseNoteRepository {
+    /**
+     * The Prisma client used to interact with the database.
+     */
+    #prisma: PrismaClient;
+
+    /**
+     * Repository class for managing case notes.
+     *
+     * @param prisma The Prisma client used to interact with the database.
+     */
+    constructor(prisma: PrismaClient) {
+        this.#prisma = prisma;
+    }
+
+    /**
+     * Creates a new case note.
+     *
+     * @param guildID The ID of the guild.
+     * @param caseID The ID of the case.
+     * @param options The options for the case note.
+     * @returns The new case note record.
+     */
+    async create(options: CreateCaseNoteOptions): Promise<CaseNote> {
+        const noteID = await this.nextInSequence(options.guildID, options.caseID);
+        return this.#prisma.caseNote.create({
+            data: {
+                caseID: options.caseID,
+                content: options.content,
+                creatorID: options.creatorID,
+                guildID: options.guildID,
+                id: noteID
+            }
+        });
+    }
+
+    /**
+     * Deletes a case note.
+     *
+     * @param guildID The ID of the guild.
+     * @param caseID The ID of the case.
+     * @param noteID The ID of the note.
+     * @returns The deleted case note record.
+     */
+    async delete(guildID: string, caseID: number, noteID: number): Promise<CaseNote> {
+        return this.#prisma.caseNote.delete({
+            where: {
+                guildID_caseID_id: {
+                    caseID: caseID,
+                    guildID: guildID,
+                    id: noteID
+                }
+            }
+        });
+    }
+
+    /**
+     * Gets the next note ID in the sequence for the specified case.
+     *
+     * @param guildID The ID of the guild.
+     * @param caseID The ID of the case.
+     * @returns The next note ID in the sequence.
+     */
+    async nextInSequence(guildID: string, caseID: number): Promise<number> {
+        return this.#prisma.caseNote
+            .aggregate({
+                where: { guildID, caseID },
+                _max: { id: true }
+            })
+            .then(({ _max }) => _max.id !== null ? _max.id + 1 : 1);
+    }
+
+    /**
+     * Updates a case note.
+     *
+     * @param guildID The ID of the guild.
+     * @param caseID The ID of the case.
+     * @param noteID The ID of the note.
+     * @param options The options for the case note.
+     * @returns The updated case note record.
+     */
+    async update(
+        guildID: string,
+        caseID: number,
+        noteID: number,
+        options: Prisma.CaseNoteUpdateInput
+    ): Promise<CaseNote> {
+        return this.#prisma.caseNote.update({
+            data: options,
+            where: {
+                guildID_caseID_id: {
+                    caseID: caseID,
+                    guildID: guildID,
+                    id: noteID
+                }
+            }
+        });
+    }
+}
+
+/**
+ * Repository class for managing settings for the moderation module.
+ */
+export class ModerationSettingsRepository {
+    /**
+     * The Prisma client used to interact with the database.
+     */
+    #prisma: PrismaClient;
+
+    /**
+     * Repository class for managing settings for the moderation module.
+     *
+     * @param prisma The Prisma client used to interact with the database.
+     */
+    constructor(prisma: PrismaClient) {
+        this.#prisma = prisma;
+    }
+
+    /**
+     * If a record exists for the specified guild, return it, otherwise create a new one.
+     *
+     * @param guildID The ID of the guild.
+     * @returns The moderation settings record.
+     */
+    async getOrCreate(guildID: string): Promise<ModerationSettings> {
+        return this.#prisma.moderationSettings.upsert({
+            create: { guildID },
+            update: {},
+            where: { guildID }
+        });
+    }
+
+    /**
+     * Upserts the moderation settings for the specified guild.
+     *
+     * @param guildID The ID of the guild.
+     * @param settings The moderation settings to update.
+     * @returns The updated moderation settings record.
+     */
+    async upsert(
+        guildID: string,
+        settings: Partial<Prisma.ModerationSettingsCreateInput>
+    ): Promise<ModerationSettings> {
+        return this.#prisma.moderationSettings.upsert({
+            create: { ...settings, guildID },
+            update: settings,
+            where: { guildID }
+        });
+    }
+}

--- a/apps/barry/src/modules/moderation/functions/permissions.ts
+++ b/apps/barry/src/modules/moderation/functions/permissions.ts
@@ -1,0 +1,58 @@
+import type {
+    APIGuild,
+    APIGuildMember,
+    APIRole,
+    APIUser
+} from "@discordjs/core";
+
+/**
+ * A partial guild member.
+ */
+export interface PartialGuildMember extends Omit<APIGuildMember, "deaf" | "mute"> {
+    user: APIUser;
+}
+
+/**
+ * Returns the highest role of a member.
+ *
+ * @param guild The guild the member is in.
+ * @param member The member to get the highest role of.
+ * @returns The highest role of the member, if any.
+ */
+export function getHighestRole(guild: APIGuild, member: PartialGuildMember): APIRole | undefined {
+    return member.roles
+        .map((id) => guild.roles.find((role) => role.id === id))
+        .filter((role) => role !== undefined)
+        .sort((a, b) => b!.position - a!.position)[0];
+}
+
+/**
+ * Returns whether a member is above another member.
+ *
+ * @param guild The guild the members are in.
+ * @param a The first member.
+ * @param b The second member.
+ * @returns Whether the first member is above the second member.
+ */
+export function isAboveMember(guild: APIGuild, a: PartialGuildMember, b: PartialGuildMember): boolean {
+    if (a.user.id === guild.owner_id) {
+        return true;
+    }
+
+    if (b.user.id === guild.owner_id) {
+        return false;
+    }
+
+    const highestA = getHighestRole(guild, a);
+    const highestB = getHighestRole(guild, b);
+
+    if (highestA === undefined) {
+        return false;
+    }
+
+    if (highestB === undefined) {
+        return true;
+    }
+
+    return highestA.position > highestB.position;
+}

--- a/apps/barry/src/modules/moderation/index.ts
+++ b/apps/barry/src/modules/moderation/index.ts
@@ -1,0 +1,58 @@
+import type { Application } from "../../Application.js";
+
+import {
+    CaseNoteRepository,
+    CaseRepository,
+    ModerationSettingsRepository
+} from "./database.js";
+import { Module } from "@barry/core";
+import { loadCommands } from "../../utils/loadFolder.js";
+
+/**
+ * Represents the moderation module.
+ */
+export default class ModerationModule extends Module<Application> {
+    /**
+     * Repository class for managing case notes.
+     */
+    caseNotes: CaseNoteRepository;
+
+    /**
+     * Repository class for managing moderation cases.
+     */
+    cases: CaseRepository;
+
+    /**
+     * Repository class for managing settings for this module.
+     */
+    moderationSettings: ModerationSettingsRepository;
+
+    /**
+     * Represents the moderation module.
+     *
+     * @param client The client that initialized this module.
+     */
+    constructor(client: Application) {
+        super(client, {
+            id: "moderation",
+            name: "Moderation",
+            description: "Easily moderate your server with powerful moderation commands.",
+            commands: loadCommands("./commands")
+        });
+
+        this.caseNotes = new CaseNoteRepository(client.prisma);
+        this.cases = new CaseRepository(client.prisma);
+        this.moderationSettings = new ModerationSettingsRepository(client.prisma);
+    }
+
+    /**
+     * Checks if the guild has enabled this module.
+     *
+     * @param guildID The ID of the guild to check.
+     * @returns Whether the guild has enabled this module.
+     */
+    async isEnabled(guildID: string): Promise<boolean> {
+        const settings = await this.moderationSettings.getOrCreate(guildID);
+        return settings.enabled;
+    }
+}

--- a/apps/barry/tests/modules/moderation/commands/chatinput/warn/index.test.ts
+++ b/apps/barry/tests/modules/moderation/commands/chatinput/warn/index.test.ts
@@ -1,0 +1,324 @@
+import { type Case, CaseType } from "@prisma/client";
+
+import { ApplicationCommandInteraction, AutocompleteInteraction } from "@barry/core";
+import { ApplicationCommandType, MessageFlags } from "@discordjs/core";
+import {
+    createMockApplicationCommandInteraction,
+    createMockAutocompleteInteraction,
+    mockChannel,
+    mockMember,
+    mockMessage,
+    mockUser
+} from "@barry/testing";
+
+import { COMMON_MINOR_REASONS } from "../../../../../../src/modules/moderation/constants.js";
+import { DiscordAPIError } from "@discordjs/rest";
+import { createMockApplication } from "../../../../../mocks/application.js";
+import { mockGuild } from "@barry/testing";
+
+import WarnCommand, { type WarnOptions } from "../../../../../../src/modules/moderation/commands/chatinput/warn/index.js";
+import ModerationModule from "../../../../../../src/modules/moderation/index.js";
+
+import * as permissions from "../../../../../../src/modules/moderation/functions/permissions.js";
+
+describe("/warn", () => {
+    let command: WarnCommand;
+    let interaction: ApplicationCommandInteraction;
+    let options: WarnOptions;
+
+    beforeEach(() => {
+        const client = createMockApplication();
+
+        const module = new ModerationModule(client);
+        command = new WarnCommand(module);
+
+        const data = createMockApplicationCommandInteraction();
+        interaction = new ApplicationCommandInteraction(data, client, vi.fn());
+        options = {
+            member: {
+                ...mockMember,
+                user: {
+                    ...mockUser,
+                    id: "257522665437265920"
+                }
+            },
+            reason: "Rude!"
+        };
+
+        vi.spyOn(command.client.api.channels, "createMessage").mockResolvedValue(mockMessage);
+        vi.spyOn(command.client.api.guilds, "get").mockResolvedValue(mockGuild);
+        vi.spyOn(command.client.api.guilds, "getMember").mockResolvedValue(mockMember);
+        vi.spyOn(command.client.api.users, "createDM").mockResolvedValue({ ...mockChannel, position: 0 });
+        vi.spyOn(command.module.cases, "create").mockResolvedValue({
+            createdAt: new Date("1-1-2023"),
+            creatorID: mockUser.id,
+            guildID: mockGuild.id,
+            id: 34,
+            type: CaseType.Warn,
+            userID: "257522665437265920"
+        });
+        vi.spyOn(command.module.cases, "getByUser").mockResolvedValue([]);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe("execute", () => {
+        it("should ignore if the interaction was sent outside a guild", async () => {
+            delete interaction.guildID;
+
+            await command.execute(interaction, options);
+
+            expect(interaction.acknowledged).toBe(false);
+        });
+
+        it("should show an error message if the moderator tries to warn themselves", async () => {
+            const createSpy = vi.spyOn(interaction, "createMessage");
+            options.member.user.id = interaction.user.id;
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith({
+                content: expect.stringContaining("You cannot warn yourself."),
+                flags: MessageFlags.Ephemeral
+            });
+        });
+
+        it("should show an error message if the moderator tries to warn the bot", async () => {
+            const createSpy = vi.spyOn(interaction, "createMessage");
+            options.member.user.id = command.client.applicationID;
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith({
+                content: expect.stringContaining("Your attempt to warn me has been classified as a failed comedy show audition."),
+                flags: MessageFlags.Ephemeral
+            });
+        });
+
+        it("should show an error message if the moderator is below the target", async () => {
+            vi.spyOn(permissions, "isAboveMember").mockReturnValue(false);
+            const createSpy = vi.spyOn(interaction, "createMessage");
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith({
+                content: expect.stringContaining("You cannot warn a member with a higher or equal role to you."),
+                flags: MessageFlags.Ephemeral
+            });
+        });
+
+        it("should show an error message if the bot is below the target", async () => {
+            vi.spyOn(permissions, "isAboveMember")
+                .mockReturnValueOnce(true)
+                .mockReturnValue(false);
+            const createSpy = vi.spyOn(interaction, "createMessage");
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith({
+                content: expect.stringContaining("I cannot warn a member with a higher or equal role to me."),
+                flags: MessageFlags.Ephemeral
+            });
+        });
+
+        it("should send a direct message to the target", async () => {
+            vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+            const createSpy = vi.spyOn(command.client.api.channels, "createMessage");
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith(mockChannel.id, {
+                embeds: [{
+                    color: expect.any(Number),
+                    description: expect.stringContaining("You have been warned in **Barry's Server**"),
+                    fields: [{
+                        name: "**Reason**",
+                        value: options.reason
+                    }]
+                }]
+            });
+        });
+
+        it("should log an error if the direct message fails due to an unknown error", async () => {
+            const error = new Error("Oh no!");
+            vi.spyOn(command.client.api.channels, "createMessage").mockRejectedValue(error);
+            vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+
+            await command.execute(interaction, options);
+
+            expect(command.client.logger.error).toHaveBeenCalledOnce();
+            expect(command.client.logger.error).toHaveBeenCalledWith(error);
+        });
+
+        it("should create a new case in the database", async () => {
+            vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+            const createSpy = vi.spyOn(command.module.cases, "create");
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith({
+                creatorID: interaction.user.id,
+                guildID: interaction.guildID,
+                note: options.reason,
+                type: CaseType.Warn,
+                userID: options.member.user.id
+            });
+        });
+    });
+
+    describe("#onSuccess", () => {
+        let error: Error;
+
+        beforeEach(() => {
+            const response = {
+                code: 50007,
+                message: "Cannot send messages to this user"
+            };
+
+            error = new DiscordAPIError(response, 50007, 200, "GET", "", {});
+        });
+
+        it("should send a success message to the moderator", async () => {
+            vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+            const createSpy = vi.spyOn(interaction, "createMessage");
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith({
+                content: expect.stringContaining(`Case \`34\` | Successfully warned \`${options.member.user.username}\`.`),
+                flags: MessageFlags.Ephemeral
+            });
+        });
+
+        it("should send a success message if the target's DMs are disabled", async () => {
+            vi.spyOn(command.client.api.channels, "createMessage").mockRejectedValue(error);
+            vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+            const createSpy = vi.spyOn(interaction, "createMessage");
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith({
+                content: expect.stringContaining(`Case \`34\` | Successfully warned \`${options.member.user.username}\`. However, they have disabled their DMs, so I was unable to notify them.`),
+                flags: MessageFlags.Ephemeral
+            });
+        });
+
+        it("should send a success message if the target has already received a warning before", async () => {
+            vi.spyOn(command.module.cases, "getByUser").mockResolvedValue([
+                { id: 1 } as Case,
+                { id: 34 } as Case
+            ]);
+            vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+            const createSpy = vi.spyOn(interaction, "createMessage");
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith({
+                content: expect.stringContaining(`Case \`34\` | Successfully warned \`${options.member.user.username}\`. They already have a warning; please review their previous cases and take action if needed.`),
+                flags: MessageFlags.Ephemeral
+            });
+        });
+
+        it("should send a success message if the target has already received multiple warnings before", async () => {
+            vi.spyOn(command.module.cases, "getByUser").mockResolvedValue([
+                { id: 1 } as Case,
+                { id: 5 } as Case,
+                { id: 34 } as Case
+            ]);
+            vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+            const createSpy = vi.spyOn(interaction, "createMessage");
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith({
+                content: expect.stringContaining(`Case \`34\` | Successfully warned \`${options.member.user.username}\`. They currently have \`2\` warnings; please review their previous cases and take action if needed.`),
+                flags: MessageFlags.Ephemeral
+            });
+        });
+
+        it("should send a success message if the target's DMs are disabled and they have already received a warning before", async () => {
+            vi.spyOn(command.client.api.channels, "createMessage").mockRejectedValue(error);
+            vi.spyOn(command.module.cases, "getByUser").mockResolvedValue([
+                { id: 1 } as Case,
+                { id: 34 } as Case
+            ]);
+            vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+            const createSpy = vi.spyOn(interaction, "createMessage");
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith({
+                content: expect.stringContaining(`Case \`34\` | Successfully warned \`${options.member.user.username}\`. However, they have disabled their DMs, so I was unable to notify them. They already have a warning; please review their previous cases and take action if needed.`),
+                flags: MessageFlags.Ephemeral
+            });
+        });
+
+        it("should send a success message if the target's DMs are disabled and they have already received multiple warnings before", async () => {
+            vi.spyOn(command.client.api.channels, "createMessage").mockRejectedValue(error);
+            vi.spyOn(command.module.cases, "getByUser").mockResolvedValue([
+                { id: 1 } as Case,
+                { id: 5 } as Case,
+                { id: 34 } as Case
+            ]);
+            vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+            const createSpy = vi.spyOn(interaction, "createMessage");
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith({
+                content: expect.stringContaining(`Case \`34\` | Successfully warned \`${options.member.user.username}\`. However, they have disabled their DMs, so I was unable to notify them. They currently have \`2\` warnings; please review their previous cases and take action if needed.`),
+                flags: MessageFlags.Ephemeral
+            });
+        });
+    });
+
+    describe("Autocomplete 'reason'", () => {
+        it("should show a predefined list of reasons if no value is provided", async () => {
+            const data = createMockAutocompleteInteraction({
+                id: "49072635294295155",
+                name: "warn",
+                options: [],
+                type: ApplicationCommandType.ChatInput
+            });
+            const interaction = new AutocompleteInteraction(data, command.client, vi.fn());
+
+            const result = await command.options[1].autocomplete?.("" as never, interaction);
+
+            expect(result).toEqual(COMMON_MINOR_REASONS.map((x) => ({ name: x, value: x })));
+        });
+
+        it("should show a matching predefined option if the option starts with the value", async () => {
+            const data = createMockAutocompleteInteraction({
+                id: "49072635294295155",
+                name: "warn",
+                options: [],
+                type: ApplicationCommandType.ChatInput
+            });
+            const interaction = new AutocompleteInteraction(data, command.client, vi.fn());
+
+            const result = await command.options[1].autocomplete?.(
+                COMMON_MINOR_REASONS[0].slice(0, 5) as never,
+                interaction
+            );
+
+            expect(result).toEqual([{
+                name: COMMON_MINOR_REASONS[0],
+                value: COMMON_MINOR_REASONS[0]
+            }]);
+        });
+    });
+});

--- a/apps/barry/tests/modules/moderation/database.test.ts
+++ b/apps/barry/tests/modules/moderation/database.test.ts
@@ -1,0 +1,476 @@
+import {
+    type Case,
+    type CaseNote,
+    type ModerationSettings,
+    CaseType,
+    Prisma
+} from "@prisma/client";
+import {
+    CaseNoteRepository,
+    CaseRepository,
+    ModerationSettingsRepository
+} from "../../../src/modules/moderation/database.js";
+import { prisma } from "../../mocks/index.js";
+
+describe("CaseRepository", () => {
+    const creatorID = "257522665441460225";
+    const guildID = "68239102456844360";
+    const userID = "257522665437265920";
+
+    let repository: CaseRepository;
+
+    beforeEach(() => {
+        repository = new CaseRepository(prisma);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe("create", () => {
+        it("should create a new case record", async () => {
+            vi.spyOn(repository, "nextInSequence").mockResolvedValue(1);
+
+            await repository.create({
+                creatorID: creatorID,
+                guildID: guildID,
+                note: "Rude!",
+                type: CaseType.Ban,
+                userID: userID
+            });
+
+            expect(prisma.case.create).toHaveBeenCalledOnce();
+            expect(prisma.case.create).toHaveBeenCalledWith({
+                data: {
+                    creatorID: creatorID,
+                    guildID: guildID,
+                    id: 1,
+                    notes: {
+                        create: {
+                            content: "Rude!",
+                            creatorID: creatorID,
+                            id: 1
+                        }
+                    },
+                    type: CaseType.Ban,
+                    userID: userID
+                }
+            });
+        });
+    });
+
+    describe("delete", () => {
+        it("should delete the specified case record", async () => {
+            await repository.delete(guildID, 1);
+
+            expect(prisma.case.delete).toHaveBeenCalledOnce();
+            expect(prisma.case.delete).toHaveBeenCalledWith({
+                where: {
+                    guildID_id: {
+                        guildID: guildID,
+                        id: 1
+                    }
+                }
+            });
+        });
+    });
+
+    describe("get", () => {
+        let mockCase: Case & { notes?: CaseNote[] };
+
+        beforeEach(() => {
+            mockCase = {
+                createdAt: new Date("01-01-2023"),
+                creatorID: creatorID,
+                guildID: guildID,
+                id: 1,
+                type: CaseType.Ban,
+                userID: userID
+            };
+        });
+
+        it("should retrieve the specified case record", async () => {
+            vi.mocked(prisma.case.findUnique).mockResolvedValue(mockCase);
+
+            const entity = await repository.get(guildID, 1);
+
+            expect(entity).toEqual(mockCase);
+            expect(prisma.case.findUnique).toHaveBeenCalledOnce();
+            expect(prisma.case.findUnique).toHaveBeenCalledWith({
+                include: { notes: false },
+                where: {
+                    guildID_id: {
+                        guildID: guildID,
+                        id: 1
+                    }
+                }
+            });
+        });
+
+        it("should include the notes if specified", async () => {
+            mockCase.notes = [{
+                caseID: 1,
+                content: "Rude!",
+                createdAt: new Date("01-01-2023"),
+                creatorID: creatorID,
+                guildID: guildID,
+                id: 1
+            }];
+            vi.mocked(prisma.case.findUnique).mockResolvedValue(mockCase);
+
+            const entity = await repository.get(guildID, 1, true);
+
+            expect(entity).toEqual(mockCase);
+            expect(prisma.case.findUnique).toHaveBeenCalledOnce();
+            expect(prisma.case.findUnique).toHaveBeenCalledWith({
+                include: { notes: true },
+                where: {
+                    guildID_id: {
+                        guildID: guildID,
+                        id: 1
+                    }
+                }
+            });
+        });
+
+        it("should return null if the case record does not exist", async () => {
+            vi.mocked(prisma.case.findUnique).mockResolvedValue(null);
+
+            const entity = await repository.get(guildID, 1);
+
+            expect(entity).toEqual(null);
+        });
+    });
+
+    describe("getAll", () => {
+        let mockCases: Case[];
+
+        beforeEach(() => {
+            mockCases = [{
+                createdAt: new Date("01-01-2023"),
+                creatorID: creatorID,
+                guildID: guildID,
+                id: 1,
+                type: CaseType.Ban,
+                userID: userID
+            }, {
+                createdAt: new Date("01-01-2023"),
+                creatorID: creatorID,
+                guildID: guildID,
+                id: 2,
+                type: CaseType.Ban,
+                userID: userID
+            }];
+        });
+
+        it("should return all cases for the specified guild", async () => {
+            vi.mocked(prisma.case.findMany).mockResolvedValue(mockCases);
+
+            const entities = await repository.getAll(guildID);
+
+            expect(entities).toEqual(mockCases);
+            expect(prisma.case.findMany).toHaveBeenCalledOnce();
+            expect(prisma.case.findMany).toHaveBeenCalledWith({
+                where: { guildID }
+            });
+        });
+
+        it("should return all cases for the specified guild and type", async () => {
+            vi.mocked(prisma.case.findMany).mockResolvedValue(mockCases);
+
+            const entities = await repository.getAll(guildID, CaseType.Ban);
+
+            expect(entities).toEqual(mockCases);
+            expect(prisma.case.findMany).toHaveBeenCalledOnce();
+            expect(prisma.case.findMany).toHaveBeenCalledWith({
+                where: {
+                    guildID: guildID,
+                    type: CaseType.Ban
+                }
+            });
+        });
+
+        it("should return an empty array if no cases exist for the specified guild", async () => {
+            vi.mocked(prisma.case.findMany).mockResolvedValue([]);
+
+            const entities = await repository.getAll(guildID, CaseType.Ban);
+
+            expect(entities).toEqual([]);
+        });
+    });
+
+    describe("getByUser", () => {
+        let mockCases: Case[];
+
+        beforeEach(() => {
+            mockCases = [{
+                createdAt: new Date("01-01-2023"),
+                creatorID: creatorID,
+                guildID: guildID,
+                id: 1,
+                type: CaseType.Ban,
+                userID: userID
+            }, {
+                createdAt: new Date("01-01-2023"),
+                creatorID: creatorID,
+                guildID: guildID,
+                id: 2,
+                type: CaseType.Ban,
+                userID: userID
+            }];
+        });
+
+        it("should return all cases for the specified user", async () => {
+            vi.mocked(prisma.case.findMany).mockResolvedValue(mockCases);
+
+            const entities = await repository.getByUser(guildID, userID);
+
+            expect(entities).toEqual(mockCases);
+            expect(prisma.case.findMany).toHaveBeenCalledOnce();
+            expect(prisma.case.findMany).toHaveBeenCalledWith({
+                where: { guildID, userID }
+            });
+        });
+
+        it("should return all cases for the specified user and type", async () => {
+            vi.mocked(prisma.case.findMany).mockResolvedValue(mockCases);
+
+            const entities = await repository.getByUser(guildID, userID, CaseType.Ban);
+
+            expect(entities).toEqual(mockCases);
+            expect(prisma.case.findMany).toHaveBeenCalledOnce();
+            expect(prisma.case.findMany).toHaveBeenCalledWith({
+                where: {
+                    guildID: guildID,
+                    type: CaseType.Ban,
+                    userID: userID
+                }
+            });
+        });
+
+        it("should return an empty array if no cases exist for the specified user", async () => {
+            vi.mocked(prisma.case.findMany).mockResolvedValue([]);
+
+            const entities = await repository.getByUser(guildID, userID, CaseType.Ban);
+
+            expect(entities).toEqual([]);
+        });
+    });
+
+    describe("nextInSequence", () => {
+        it("should return the next case ID in the sequence for the specified guild", async () => {
+            vi.mocked(prisma.case.aggregate).mockResolvedValue({
+                _max: { id: 1 }
+            } as Prisma.GetCaseAggregateType<Prisma.CaseAggregateArgs>);
+
+            const id = await repository.nextInSequence(guildID);
+
+            expect(id).toEqual(2);
+            expect(prisma.case.aggregate).toHaveBeenCalledOnce();
+            expect(prisma.case.aggregate).toHaveBeenCalledWith({
+                where: { guildID },
+                _max: { id: true }
+            });
+        });
+
+        it("should return 1 if no cases exist for the specified guild", async () => {
+            vi.mocked(prisma.case.aggregate).mockResolvedValue({
+                _max: { id: null }
+            } as Prisma.GetCaseAggregateType<Prisma.CaseAggregateArgs>);
+
+            const id = await repository.nextInSequence(guildID);
+
+            expect(id).toEqual(1);
+            expect(prisma.case.aggregate).toHaveBeenCalledOnce();
+            expect(prisma.case.aggregate).toHaveBeenCalledWith({
+                where: { guildID },
+                _max: { id: true }
+            });
+        });
+    });
+
+    describe("update", () => {
+        it("should update the specified case record", async () => {
+            await repository.update(guildID, 1, {
+                type: CaseType.Ban
+            });
+
+            expect(prisma.case.update).toHaveBeenCalledOnce();
+            expect(prisma.case.update).toHaveBeenCalledWith({
+                data: {
+                    type: CaseType.Ban
+                },
+                where: {
+                    guildID_id: {
+                        guildID: guildID,
+                        id: 1
+                    }
+                }
+            });
+        });
+    });
+});
+
+describe("CaseNoteRepository", () => {
+    const guildID = "68239102456844360";
+    let repository: CaseNoteRepository;
+
+    beforeEach(() => {
+        repository = new CaseNoteRepository(prisma);
+    });
+
+    describe("create", () => {
+        it("should create a new case note record", async () => {
+            vi.spyOn(repository, "nextInSequence").mockResolvedValue(1);
+
+            await repository.create({
+                caseID: 1,
+                content: "Rude!",
+                creatorID: "257522665441460225",
+                guildID: guildID
+            });
+
+            expect(prisma.caseNote.create).toHaveBeenCalledOnce();
+            expect(prisma.caseNote.create).toHaveBeenCalledWith({
+                data: {
+                    caseID: 1,
+                    content: "Rude!",
+                    creatorID: "257522665441460225",
+                    guildID: guildID,
+                    id: 1
+                }
+            });
+        });
+    });
+
+    describe("delete", () => {
+        it("should delete the specified case note record", async () => {
+            await repository.delete(guildID, 1, 1);
+
+            expect(prisma.caseNote.delete).toHaveBeenCalledOnce();
+            expect(prisma.caseNote.delete).toHaveBeenCalledWith({
+                where: {
+                    guildID_caseID_id: {
+                        caseID: 1,
+                        guildID: guildID,
+                        id: 1
+                    }
+                }
+            });
+        });
+    });
+
+    describe("nextInSequence", () => {
+        it("should return the next note ID in the sequence for the specified case", async () => {
+            vi.mocked(prisma.caseNote.aggregate).mockResolvedValue({
+                _max: { id: 1 }
+            } as Prisma.GetCaseAggregateType<Prisma.CaseAggregateArgs>);
+
+            const id = await repository.nextInSequence(guildID, 1);
+
+            expect(id).toEqual(2);
+            expect(prisma.caseNote.aggregate).toHaveBeenCalledOnce();
+            expect(prisma.caseNote.aggregate).toHaveBeenCalledWith({
+                where: {
+                    caseID: 1,
+                    guildID: guildID
+                },
+                _max: { id: true }
+            });
+        });
+
+        it("should return 1 if no notes exist for the specified case", async () => {
+            vi.mocked(prisma.caseNote.aggregate).mockResolvedValue({
+                _max: { id: null }
+            } as Prisma.GetCaseAggregateType<Prisma.CaseAggregateArgs>);
+
+            const id = await repository.nextInSequence(guildID, 1);
+
+            expect(id).toEqual(1);
+            expect(prisma.caseNote.aggregate).toHaveBeenCalledOnce();
+            expect(prisma.caseNote.aggregate).toHaveBeenCalledWith({
+                where: {
+                    caseID: 1,
+                    guildID: guildID
+                },
+                _max: { id: true }
+            });
+        });
+    });
+
+    describe("update", () => {
+        it("should update the specified case note record", async () => {
+            await repository.update(guildID, 1, 1, {
+                content: "Really rude!"
+            });
+
+            expect(prisma.caseNote.update).toHaveBeenCalledOnce();
+            expect(prisma.caseNote.update).toHaveBeenCalledWith({
+                data: {
+                    content: "Really rude!"
+                },
+                where: {
+                    guildID_caseID_id: {
+                        caseID: 1,
+                        guildID: guildID,
+                        id: 1
+                    }
+                }
+            });
+        });
+    });
+});
+
+describe("ModerationSettingsRepository", () => {
+    const guildID = "68239102456844360";
+
+    let repository: ModerationSettingsRepository;
+    let mockSettings: ModerationSettings;
+
+    beforeEach(() => {
+        repository = new ModerationSettingsRepository(prisma);
+        mockSettings = {
+            channelID: "30527482987641765",
+            dwcDays: 7,
+            dwcRoleID: null,
+            enabled: true,
+            guildID: guildID
+        };
+    });
+
+    describe("getOrCreate", () => {
+        it("should return the moderation settings for the specified guild", async () => {
+            vi.mocked(prisma.moderationSettings.upsert).mockResolvedValue(mockSettings);
+
+            const settings = await repository.getOrCreate(guildID);
+
+            expect(settings).toEqual(mockSettings);
+            expect(prisma.moderationSettings.upsert).toHaveBeenCalledOnce();
+            expect(prisma.moderationSettings.upsert).toHaveBeenCalledWith({
+                create: { guildID },
+                update: {},
+                where: { guildID }
+            });
+        });
+    });
+
+    describe("upsert", () => {
+        it("should upsert the moderation settings for the specified guild", async () => {
+            await repository.upsert(guildID, {
+                channelID: "30527482987641765"
+            });
+
+            expect(prisma.moderationSettings.upsert).toHaveBeenCalledOnce();
+            expect(prisma.moderationSettings.upsert).toHaveBeenCalledWith({
+                create: {
+                    channelID: "30527482987641765",
+                    guildID: guildID
+                },
+                update: {
+                    channelID: "30527482987641765"
+                },
+                where: { guildID }
+            });
+        });
+    });
+});

--- a/apps/barry/tests/modules/moderation/functions/permissions.test.ts
+++ b/apps/barry/tests/modules/moderation/functions/permissions.test.ts
@@ -1,0 +1,162 @@
+import type { APIGuild, APIRole } from "@discordjs/core";
+import { getHighestRole, isAboveMember } from "../../../../src/modules/moderation/functions/permissions.js";
+import { mockGuild, mockMember } from "@barry/testing";
+
+describe("Permissions", () => {
+    let guild: APIGuild;
+
+    beforeEach(() => {
+        guild = {
+            ...mockGuild, roles: [
+                { id: "1", position: 1 } as APIRole,
+                { id: "2", position: 2 } as APIRole,
+                { id: "3", position: 3 } as APIRole
+            ]
+        };
+    });
+
+    describe("getHighestRole", () => {
+        it("should return the highest role of a member", () => {
+            const member = { ...mockMember, roles: ["1", "2", "3"] };
+
+            const role = getHighestRole(guild, member);
+
+            expect(role).toEqual(guild.roles[2]);
+        });
+
+        it("should return undefined if the member has no roles", () => {
+            const role = getHighestRole(mockGuild, mockMember);
+
+            expect(role).toBeUndefined();
+        });
+    });
+
+    describe("isAboveMember", () => {
+        it("should return true if the first member is the guild owner", () => {
+            const memberA = {
+                ...mockMember,
+                user: {
+                    ...mockMember.user,
+                    id: mockGuild.owner_id
+                }
+            };
+
+            const result = isAboveMember(mockGuild, memberA, mockMember);
+
+            expect(result).toBe(true);
+        });
+
+        it("should return false if the second member is the guild owner", () => {
+            const memberA = {
+                ...mockMember,
+                user: {
+                    ...mockMember.user,
+                    id: "257522665437265920"
+                }
+            };
+            const memberB = {
+                ...mockMember,
+                user: {
+                    ...mockMember.user,
+                    id: mockGuild.owner_id
+                }
+            };
+
+            const result = isAboveMember(mockGuild, memberA, memberB);
+
+            expect(result).toBe(false);
+        });
+
+        it("should return true if the first member has a higher role than the second member", () => {
+            const memberA = {
+                ...mockMember,
+                roles: ["1", "2", "3"],
+                user: {
+                    ...mockMember.user,
+                    id: "257522665437265920"
+                }
+            };
+            const memberB = {
+                ...mockMember,
+                roles: ["1", "2"],
+                user: {
+                    ...mockMember.user,
+                    id: "257522665458237440"
+                }
+            };
+
+            const result = isAboveMember(guild, memberA, memberB);
+
+            expect(result).toBe(true);
+        });
+
+        it("should return false if the first member has a lower role than the second member", () => {
+            const memberA = {
+                ...mockMember,
+                roles: ["1", "2"],
+                user: {
+                    ...mockMember.user,
+                    id: "257522665437265920"
+                }
+            };
+            const memberB = {
+                ...mockMember,
+                roles: ["1", "2", "3"],
+                user: {
+                    ...mockMember.user,
+                    id: "257522665458237440"
+                }
+            };
+
+            const result = isAboveMember(guild, memberA, memberB);
+
+            expect(result).toBe(false);
+        });
+
+        it("should return false if the first member has no roles", () => {
+            const memberA = {
+                ...mockMember,
+                roles: [],
+                user: {
+                    ...mockMember.user,
+                    id: "257522665437265920"
+                }
+            };
+            const memberB = {
+                ...mockMember,
+                roles: ["1", "2", "3"],
+                user: {
+                    ...mockMember.user,
+                    id: "257522665458237440"
+                }
+            };
+
+            const result = isAboveMember(guild, memberA, memberB);
+
+            expect(result).toBe(false);
+        });
+
+        it("should return true if the second member has no roles", () => {
+            const memberA = {
+                ...mockMember,
+                roles: ["1", "2", "3"],
+                user: {
+                    ...mockMember.user,
+                    id: "257522665437265920"
+                }
+            };
+            const memberB = {
+                ...mockMember,
+                roles: [],
+                user: {
+                    ...mockMember.user,
+                    id: "257522665458237440"
+                }
+            };
+
+            const result = isAboveMember(guild, memberA, memberB);
+
+            expect(result).toBe(true);
+        });
+    });
+});

--- a/apps/barry/tests/modules/moderation/index.test.ts
+++ b/apps/barry/tests/modules/moderation/index.test.ts
@@ -1,0 +1,60 @@
+import type { ModerationSettings } from "@prisma/client";
+
+import {
+    CaseNoteRepository,
+    CaseRepository,
+    ModerationSettingsRepository
+} from "../../../src/modules/moderation/database.js";
+import { createMockApplication } from "../../mocks/application.js";
+import { mockGuild } from "@barry/testing";
+
+import ModerationModule from "../../../src/modules/moderation/index.js";
+
+describe("ModerationModule", () => {
+    let module: ModerationModule;
+    let settings: ModerationSettings;
+
+    beforeEach(() => {
+        const client = createMockApplication();
+        module = new ModerationModule(client);
+
+        settings = {
+            channelID: null,
+            dwcDays: 7,
+            dwcRoleID: null,
+            enabled: true,
+            guildID: mockGuild.id
+        };
+    });
+
+    describe("constructor", () => {
+        it("should set up the repositories correctly", () => {
+            expect(module.caseNotes).toBeInstanceOf(CaseNoteRepository);
+            expect(module.cases).toBeInstanceOf(CaseRepository);
+            expect(module.moderationSettings).toBeInstanceOf(ModerationSettingsRepository);
+        });
+    });
+
+    describe("isEnabled", () => {
+        it("should return true if the guild has the module enabled", async () => {
+            const settingsSpy = vi.spyOn(module.moderationSettings, "getOrCreate").mockResolvedValue(settings);
+
+            const enabled = await module.isEnabled("68239102456844360");
+
+            expect(settingsSpy).toHaveBeenCalledOnce();
+            expect(settingsSpy).toHaveBeenCalledWith("68239102456844360");
+            expect(enabled).toBe(true);
+        });
+
+        it("should return false if the guild has the module disabled", async () => {
+            const settingsSpy = vi.spyOn(module.moderationSettings, "getOrCreate").mockResolvedValue(settings);
+            settings.enabled = false;
+
+            const enabled = await module.isEnabled("68239102456844360");
+
+            expect(settingsSpy).toHaveBeenCalledOnce();
+            expect(settingsSpy).toHaveBeenCalledWith("68239102456844360");
+            expect(enabled).toBe(false);
+        });
+    });
+});

--- a/packages/testing/src/mocks/common.ts
+++ b/packages/testing/src/mocks/common.ts
@@ -1,5 +1,6 @@
 import {
     type APIAttachment,
+    type APIGuild,
     type APIGuildMember,
     type APIInteractionDataResolvedChannel,
     type APIInteractionGuildMember,
@@ -7,7 +8,14 @@ import {
     type APIPartialChannel,
     type APIRole,
     type APIUser,
-    ChannelType
+    ChannelType,
+    GuildDefaultMessageNotifications,
+    GuildExplicitContentFilter,
+    GuildMFALevel,
+    GuildNSFWLevel,
+    GuildPremiumTier,
+    GuildSystemChannelFlags,
+    GuildVerificationLevel
 } from "@discordjs/core";
 
 /**
@@ -30,6 +38,43 @@ export const mockChannel = {
     name: "general",
     type: ChannelType.GuildText
 } satisfies APIPartialChannel;
+
+/**
+ * Represents a guild.
+ */
+export const mockGuild = {
+    afk_channel_id: null,
+    afk_timeout: 900,
+    application_id: null,
+    banner: null,
+    default_message_notifications: GuildDefaultMessageNotifications.OnlyMentions,
+    description: null,
+    discovery_splash: null,
+    emojis: [],
+    explicit_content_filter: GuildExplicitContentFilter.AllMembers,
+    features: [],
+    hub_type: null,
+    icon: "9507a0067e219e749e74a678d14b791a",
+    id: "68239102456844360",
+    mfa_level: GuildMFALevel.None,
+    name: "Barry's Server",
+    nsfw_level: GuildNSFWLevel.Safe,
+    owner_id: "257522665441460225",
+    preferred_locale: "en-US",
+    premium_progress_bar_enabled: false,
+    premium_subscription_count: 10,
+    premium_tier: GuildPremiumTier.Tier2,
+    public_updates_channel_id: null,
+    region: "us-east",
+    roles: [],
+    rules_channel_id: null,
+    splash: null,
+    stickers: [],
+    system_channel_id: null,
+    system_channel_flags: GuildSystemChannelFlags.SuppressGuildReminderNotifications,
+    vanity_url_code: null,
+    verification_level: GuildVerificationLevel.Medium
+} satisfies APIGuild;
 
 /**
  * Represents a mock interaction channel.


### PR DESCRIPTION
Closes #17, part of #24 
- adds models for moderation
- adds basic stuff for the moderation module
- adds mock guild data to `@barry/testing`
- adds warn slash command