### PR TITLE
feat: implement mute command

### DIFF
--- a/apps/barry/src/modules/moderation/functions/getDuration.ts
+++ b/apps/barry/src/modules/moderation/functions/getDuration.ts
@@ -1,0 +1,36 @@
+/**
+ * The regex to match the duration.
+ */
+const REGEX = /(\d+)\s*(w|weeks?|d|days?|h|hours?|m|mins?|minutes?|s|seconds?)/gi;
+
+/**
+ * The time units and their corresponding values in seconds.
+ */
+const TIME_UNITS: Record<string, number> = {
+    w: 604800,
+    d: 86400,
+    h: 3600,
+    m: 60,
+    s: 1
+};
+
+/**
+ * Parses a string into a duration in seconds.
+ *
+ * @param value The string to parse.
+ * @returns The duration in seconds.
+ */
+export function getDuration(value: string): number {
+    let totalSeconds = 0;
+    let match;
+
+    while ((match = REGEX.exec(value)) !== null) {
+        const value = parseInt(match[1]);
+        const unit = match[2][0].toLowerCase();
+        if (TIME_UNITS[unit]) {
+            totalSeconds += value * TIME_UNITS[unit];
+        }
+    }
+
+    return totalSeconds;
+}

--- a/apps/barry/src/modules/moderation/functions/getLogContent.ts
+++ b/apps/barry/src/modules/moderation/functions/getLogContent.ts
@@ -23,7 +23,7 @@ export interface CaseLogOptions {
     creator: APIUser;
 
     /**
-     * The duration of the case, if applicable.
+     * The duration in seconds of the case, if applicable.
      */
     duration?: number;
 
@@ -93,7 +93,7 @@ export function getLogContent(options: CaseLogOptions): APIInteractionResponseCa
     if (options.duration !== undefined) {
         embed.fields?.push({
             name: "**Duration**",
-            value: `Expires <t:${Math.trunc((options.case.createdAt.getTime() + options.duration) / 1000)}:R>`
+            value: `Expires <t:${Math.trunc((options.case.createdAt.getTime() / 1000) + options.duration)}:R>`
         });
     }
 

--- a/apps/barry/tests/modules/moderation/commands/chatinput/mute/index.test.ts
+++ b/apps/barry/tests/modules/moderation/commands/chatinput/mute/index.test.ts
@@ -38,7 +38,7 @@ describe("/mute", () => {
         interaction = new ApplicationCommandInteraction(data, client, vi.fn());
 
         mockCase = {
-            createdAt: new Date("1-1-2023"),
+            createdAt: new Date(),
             creatorID: mockUser.id,
             guildID: mockGuild.id,
             id: 34,
@@ -97,7 +97,7 @@ describe("/mute", () => {
                         },
                         {
                             name: "**Duration**",
-                            value: "Expires <t:1672527900:R>"
+                            value: `Expires <t:${Math.trunc((Date.now() / 1000) + 300)}:R>`
                         }
                     ]
                 }]
@@ -112,7 +112,7 @@ describe("/mute", () => {
 
             expect(editSpy).toHaveBeenCalledOnce();
             expect(editSpy).toHaveBeenCalledWith(mockGuild.id, options.member.user.id, {
-                communication_disabled_until: new Date("1-1-2023 00:05:00").toISOString()
+                communication_disabled_until: new Date(Date.now() + 300000).toISOString()
             });
         });
 

--- a/apps/barry/tests/modules/moderation/commands/chatinput/mute/index.test.ts
+++ b/apps/barry/tests/modules/moderation/commands/chatinput/mute/index.test.ts
@@ -1,0 +1,329 @@
+import { type Case, type ModerationSettings, CaseType } from "@prisma/client";
+import { ApplicationCommandInteraction, AutocompleteInteraction } from "@barry/core";
+import { ApplicationCommandType, MessageFlags } from "@discordjs/core";
+import {
+    createMockApplicationCommandInteraction,
+    createMockAutocompleteInteraction,
+    mockChannel,
+    mockGuild,
+    mockMember,
+    mockMessage,
+    mockUser
+} from "@barry/testing";
+
+import { DiscordAPIError } from "@discordjs/rest";
+import { COMMON_MINOR_REASONS } from "../../../../../../src/modules/moderation/constants.js";
+import { createMockApplication } from "../../../../../mocks/application.js";
+
+import MuteCommand, { type MuteOptions } from "../../../../../../src/modules/moderation/commands/chatinput/mute/index.js";
+import ModerationModule from "../../../../../../src/modules/moderation/index.js";
+import * as duration from "../../../../../../src/modules/moderation/functions/getDuration.js";
+import * as permissions from "../../../../../../src/modules/moderation/functions/permissions.js";
+
+describe("/mute", () => {
+    let command: MuteCommand;
+    let interaction: ApplicationCommandInteraction;
+    let mockCase: Case;
+    let options: MuteOptions;
+    let settings: ModerationSettings;
+
+    beforeEach(() => {
+        vi.useFakeTimers().setSystemTime("1-1-2023");
+
+        const client = createMockApplication();
+        const module = new ModerationModule(client);
+        command = new MuteCommand(module);
+
+        const data = createMockApplicationCommandInteraction();
+        interaction = new ApplicationCommandInteraction(data, client, vi.fn());
+
+        mockCase = {
+            createdAt: new Date("1-1-2023"),
+            creatorID: mockUser.id,
+            guildID: mockGuild.id,
+            id: 34,
+            type: CaseType.Mute,
+            userID: "257522665437265920"
+        };
+        options = {
+            duration: "5m",
+            member: {
+                ...mockMember,
+                user: {
+                    ...mockUser,
+                    id: "257522665437265920"
+                }
+            },
+            reason: "Rude!"
+        };
+        settings = {
+            channelID: "30527482987641765",
+            dwcDays: 7,
+            dwcRoleID: null,
+            enabled: true,
+            guildID: "68239102456844360"
+        };
+
+        vi.spyOn(client.api.channels, "createMessage").mockResolvedValue(mockMessage);
+        vi.spyOn(client.api.guilds, "get").mockResolvedValue(mockGuild);
+        vi.spyOn(client.api.guilds, "getMember").mockResolvedValue(mockMember);
+        vi.spyOn(client.api.guilds, "editMember").mockResolvedValue(mockMember);
+        vi.spyOn(client.api.users, "createDM").mockResolvedValue({ ...mockChannel, position: 0 });
+        vi.spyOn(module.cases, "create").mockResolvedValue(mockCase);
+        vi.spyOn(module.moderationSettings, "getOrCreate").mockResolvedValue(settings);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    describe("execute", () => {
+        it("should send a direct message to the target", async () => {
+            vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+            const createSpy = vi.spyOn(command.client.api.channels, "createMessage");
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).toHaveBeenCalledTimes(2);
+            expect(createSpy).toHaveBeenCalledWith(mockChannel.id, {
+                embeds: [{
+                    color: expect.any(Number),
+                    description: expect.stringContaining("You have been muted in **Barry's Server**"),
+                    fields: [
+                        {
+                            name: "**Reason**",
+                            value: options.reason
+                        },
+                        {
+                            name: "**Duration**",
+                            value: "Expires <t:1672527900:R>"
+                        }
+                    ]
+                }]
+            });
+        });
+
+        it("should give the member a timeout", async () => {
+            vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+            const editSpy = vi.spyOn(command.client.api.guilds, "editMember");
+
+            await command.execute(interaction, options);
+
+            expect(editSpy).toHaveBeenCalledOnce();
+            expect(editSpy).toHaveBeenCalledWith(mockGuild.id, options.member.user.id, {
+                communication_disabled_until: new Date("1-1-2023 00:05:00").toISOString()
+            });
+        });
+
+        it("should create a new case in the database", async () => {
+            vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+            const createSpy = vi.spyOn(command.module.cases, "create");
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith({
+                creatorID: interaction.user.id,
+                guildID: interaction.guildID,
+                note: options.reason,
+                type: CaseType.Mute,
+                userID: options.member.user.id
+            });
+        });
+
+        it("should show a success message to the moderator", async () => {
+            vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+            const createSpy = vi.spyOn(interaction, "createMessage");
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith({
+                content: expect.stringContaining(`Case \`34\` | Successfully muted \`${options.member.user.username}\``),
+                flags: MessageFlags.Ephemeral
+            });
+        });
+
+        it("should log the case in the configured log channel", async () => {
+            vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+            const createSpy = vi.spyOn(command.module, "createLogMessage");
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith({
+                case: mockCase,
+                creator: interaction.user,
+                duration: 300,
+                reason: options.reason,
+                user: options.member.user
+            }, settings);
+        });
+
+        describe("Validating", () => {
+            it("should ignore if the interaction was sent outside a guild", async () => {
+                delete interaction.guildID;
+
+                await command.execute(interaction, options);
+
+                expect(interaction.acknowledged).toBe(false);
+            });
+
+            it("should show an error message if the moderator tries to warn themselves", async () => {
+                const createSpy = vi.spyOn(interaction, "createMessage");
+                options.member.user.id = interaction.user.id;
+
+                await command.execute(interaction, options);
+
+                expect(createSpy).toHaveBeenCalledOnce();
+                expect(createSpy).toHaveBeenCalledWith({
+                    content: expect.stringContaining("You cannot mute yourself."),
+                    flags: MessageFlags.Ephemeral
+                });
+            });
+
+            it("should show an error message if the moderator tries to warn the bot", async () => {
+                const createSpy = vi.spyOn(interaction, "createMessage");
+                options.member.user.id = command.client.applicationID;
+
+                await command.execute(interaction, options);
+
+                expect(createSpy).toHaveBeenCalledOnce();
+                expect(createSpy).toHaveBeenCalledWith({
+                    content: expect.stringContaining("Your attempt to mute me has been classified as a failed comedy show audition."),
+                    flags: MessageFlags.Ephemeral
+                });
+            });
+
+            it("should show an error message if the moderator is below the target", async () => {
+                vi.spyOn(permissions, "isAboveMember").mockReturnValue(false);
+                const createSpy = vi.spyOn(interaction, "createMessage");
+
+                await command.execute(interaction, options);
+
+                expect(createSpy).toHaveBeenCalledOnce();
+                expect(createSpy).toHaveBeenCalledWith({
+                    content: expect.stringContaining("You cannot mute this member."),
+                    flags: MessageFlags.Ephemeral
+                });
+            });
+
+            it("should show an error message if the bot is below the target", async () => {
+                vi.spyOn(permissions, "isAboveMember")
+                    .mockReturnValueOnce(true)
+                    .mockReturnValue(false);
+                const createSpy = vi.spyOn(interaction, "createMessage");
+
+                await command.execute(interaction, options);
+
+                expect(createSpy).toHaveBeenCalledOnce();
+                expect(createSpy).toHaveBeenCalledWith({
+                    content: expect.stringContaining("I cannot mute this member."),
+                    flags: MessageFlags.Ephemeral
+                });
+            });
+
+            it("should show an error message if the duration is less than 10 seconds", async () => {
+                vi.spyOn(duration, "getDuration").mockReturnValue(5);
+                const createSpy = vi.spyOn(interaction, "createMessage");
+
+                await command.execute(interaction, options);
+
+                expect(createSpy).toHaveBeenCalledOnce();
+                expect(createSpy).toHaveBeenCalledWith({
+                    content: expect.stringContaining("The duration must at least be 10 seconds."),
+                    flags: MessageFlags.Ephemeral
+                });
+            });
+
+            it("should show an error message if the duration is more than 28 days", async () => {
+                vi.spyOn(duration, "getDuration").mockReturnValue(2592000);
+                const createSpy = vi.spyOn(interaction, "createMessage");
+
+                await command.execute(interaction, options);
+
+                expect(createSpy).toHaveBeenCalledOnce();
+                expect(createSpy).toHaveBeenCalledWith({
+                    content: expect.stringContaining("The duration must not exceed 28 days."),
+                    flags: MessageFlags.Ephemeral
+                });
+            });
+        });
+
+        describe("Error handling", () => {
+            it("should log an error if the direct message fails due to an unknown error", async () => {
+                const error = new Error("Oh no!");
+                vi.spyOn(command.client.api.channels, "createMessage").mockRejectedValueOnce(error);
+                vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+
+                await command.execute(interaction, options);
+
+                expect(command.client.logger.error).toHaveBeenCalledOnce();
+                expect(command.client.logger.error).toHaveBeenCalledWith(error);
+            });
+
+            it("should ignore an error if the direct message fails due to the user disabling DMs", async () => {
+                const response = {
+                    code: 50007,
+                    message: "Cannot send messages to this user"
+                };
+
+                const error = new DiscordAPIError(response, 50007, 200, "GET", "", {});
+                vi.spyOn(command.client.api.channels, "createMessage").mockRejectedValueOnce(error);
+                vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+
+                await command.execute(interaction, options);
+
+                expect(command.client.logger.error).not.toHaveBeenCalledOnce();
+            });
+
+            it("should log an error if the mute fails due to an unknown error", async () => {
+                const error = new Error("Oh no!");
+                vi.spyOn(command.client.api.guilds, "editMember").mockRejectedValueOnce(error);
+                vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+
+                await command.execute(interaction, options);
+
+                expect(command.client.logger.error).toHaveBeenCalledOnce();
+                expect(command.client.logger.error).toHaveBeenCalledWith(error);
+            });
+        });
+    });
+
+    describe("Autocomplete 'reason'", () => {
+        it("should show a predefined list of reasons if no value is provided", async () => {
+            const data = createMockAutocompleteInteraction({
+                id: "49072635294295155",
+                name: "mute",
+                options: [],
+                type: ApplicationCommandType.ChatInput
+            });
+            const interaction = new AutocompleteInteraction(data, command.client, vi.fn());
+
+            const result = await command.options[2].autocomplete?.("" as never, interaction);
+
+            expect(result).toEqual(COMMON_MINOR_REASONS.map((x) => ({ name: x, value: x })));
+        });
+
+        it("should show a matching predefined option if the option starts with the value", async () => {
+            const data = createMockAutocompleteInteraction({
+                id: "49072635294295155",
+                name: "mute",
+                options: [],
+                type: ApplicationCommandType.ChatInput
+            });
+            const interaction = new AutocompleteInteraction(data, command.client, vi.fn());
+
+            const result = await command.options[2].autocomplete?.(
+                COMMON_MINOR_REASONS[0].slice(0, 5) as never,
+                interaction
+            );
+
+            expect(result).toEqual([{
+                name: COMMON_MINOR_REASONS[0],
+                value: COMMON_MINOR_REASONS[0]
+            }]);
+        });
+    });
+});

--- a/apps/barry/tests/modules/moderation/functions/getDuration.test.ts
+++ b/apps/barry/tests/modules/moderation/functions/getDuration.test.ts
@@ -1,0 +1,33 @@
+import { getDuration } from "../../../../src/modules/moderation/functions/getDuration.js";
+
+describe("getDuration", () => {
+    it("should parse '1h 30m' to seconds", () => {
+        const duration = getDuration("1h 30m");
+
+        expect(duration).toBe(5400);
+    });
+
+    it("should parse '1 week, 2 days, 3 hours, 45 minutes' to seconds", () => {
+        const duration = getDuration("1 week, 2 days, 3 hours, 45 minutes");
+
+        expect(duration).toBe(791100);
+    });
+
+    it("should parse '2w 3d 4h 5m 6s' to seconds", () => {
+        const duration = getDuration("2w 3d 4h 5m 6s");
+
+        expect(duration).toBe(1483506);
+    });
+
+    it("should parse '2 weeks and 3 seconds' to seconds", () => {
+        const duration = getDuration("2 weeks and 3 seconds");
+
+        expect(duration).toBe(1209603);
+    });
+
+    it("should parse '1m 30s' to seconds", () => {
+        const duration = getDuration("1m 30s");
+
+        expect(duration).toBe(90);
+    });
+});

--- a/apps/barry/tests/modules/moderation/functions/getLogContent.test.ts
+++ b/apps/barry/tests/modules/moderation/functions/getLogContent.test.ts
@@ -49,9 +49,9 @@ describe("getLogContent", () => {
     });
 
     it("should generate the correct content for a log message with a duration", () => {
-        options.duration = 1000 * 60 * 60 * 24 * 7;
+        options.duration = 60 * 60 * 24 * 7;
         const content = getLogContent(options);
-        const expiresAt = Math.trunc((options.case.createdAt.getTime() + options.duration) / 1000);
+        const expiresAt = Math.trunc((options.case.createdAt.getTime() / 1000) + options.duration);
 
         expect(content).toEqual({
             embeds: [{


### PR DESCRIPTION
Closes #16, part of #24.
- adds a `/mute` command.
- adds missing permission to `/kick`
- adds a `getDuration` method which parses the duration from a human readable string (e.g. `1 hour 5 minutes`)