### PR TITLE
feat: implement (temp)bans

### DIFF
--- a/apps/barry/prisma/schema.prisma
+++ b/apps/barry/prisma/schema.prisma
@@ -203,3 +203,12 @@ model ModerationSettings {
 
   @@map("moderation_settings")
 }
+
+model TempBan {
+  guildID   String   @map("guild_id")
+  userID    String   @map("user_id")
+  expiresAt DateTime @map("expires_at")
+
+  @@id([guildID, userID])
+  @@map("temp_bans")
+}

--- a/apps/barry/src/modules/moderation/commands/chatinput/ban/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/ban/index.ts
@@ -1,0 +1,244 @@
+import {
+    type APIUser,
+    MessageFlags,
+    PermissionFlagsBits
+} from "@discordjs/core";
+import {
+    type ApplicationCommandInteraction,
+    SlashCommand,
+    SlashCommandOptionBuilder
+} from "@barry/core";
+import { type PartialGuildMember, isAboveMember } from "../../../functions/permissions.js";
+import type ModerationModule from "../../../index.js";
+
+import { COMMON_SEVERE_REASONS } from "../../../constants.js";
+import { CaseType } from "@prisma/client";
+import { DiscordAPIError } from "@discordjs/rest";
+import { getDuration } from "../../../functions/getDuration.js";
+
+import config from "../../../../../config.js";
+
+/**
+ * Options for the ban command.
+ */
+export interface BanOptions {
+    /**
+     * Whether to delete the user's messages.
+     */
+    delete?: boolean;
+
+    /**
+     * The duration of the ban.
+     */
+    duration?: string;
+
+    /**
+     * The reason for the ban.
+     */
+    reason: string;
+
+    /**
+     * The user to ban.
+     */
+    user: APIUser;
+}
+
+/**
+ * The maximum duration in seconds (28 days).
+ */
+const MAX_DURATION = 2419200;
+
+/**
+ * The minimum duration in seconds (1 minute).
+ */
+const MIN_DURATION = 60;
+
+/**
+ * Represents a slash command that bans a user.
+ */
+export default class extends SlashCommand<ModerationModule> {
+    /**
+     * Represents a slash command that bans a user.
+     *
+     * @param module The module this command belongs to.
+     */
+    constructor(module: ModerationModule) {
+        super(module, {
+            name: "ban",
+            description: "Ban a user from the server.",
+            appPermissions: PermissionFlagsBits.BanMembers,
+            defaultMemberPermissions: PermissionFlagsBits.BanMembers,
+            guildOnly: true,
+            options: {
+                user: SlashCommandOptionBuilder.user({
+                    description: "The user to ban.",
+                    required: true
+                }),
+                reason: SlashCommandOptionBuilder.string({
+                    description: "The reason for the ban (type to enter a custom reason)",
+                    maximum: 200,
+                    required: true,
+                    autocomplete: (value) => COMMON_SEVERE_REASONS
+                        .filter((x) => x.toLowerCase().startsWith(value.toLowerCase()))
+                        .map((x) => ({ name: x, value: x }))
+                }),
+                delete: SlashCommandOptionBuilder.boolean({
+                    description: "Whether to delete the user's messages."
+                }),
+                duration: SlashCommandOptionBuilder.string({
+                    description: "The duration of the ban."
+                })
+            }
+        });
+    }
+
+    /**
+     * Bans a user from the server.
+     *
+     * @param interaction The interaction that triggered the command.
+     * @param options The options for the command.
+     */
+    async execute(interaction: ApplicationCommandInteraction, options: BanOptions): Promise<void> {
+        if (!interaction.isInvokedInGuild() || !interaction.data.isChatInput()) {
+            return;
+        }
+
+        let duration: number | undefined;
+        if (options.duration !== undefined) {
+            duration = getDuration(options.duration);
+            if (duration < MIN_DURATION) {
+                return interaction.createMessage({
+                    content: `${config.emotes.error} The duration must at least be 60 seconds.`,
+                    flags: MessageFlags.Ephemeral
+                });
+            }
+
+            if (duration > MAX_DURATION) {
+                return interaction.createMessage({
+                    content: `${config.emotes.error} The duration must not exceed 28 days.`,
+                    flags: MessageFlags.Ephemeral
+                });
+            }
+        }
+
+        if (options.user.id === interaction.user.id) {
+            return interaction.createMessage({
+                content: `${config.emotes.error} You cannot ban yourself.`,
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
+        if (options.user.id === this.client.applicationID) {
+            return interaction.createMessage({
+                content: `${config.emotes.error} Your attempt to ban me has been classified as a failed comedy show audition.`,
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
+        const guild = await this.client.api.guilds.get(interaction.guildID);
+        const member = interaction.data.resolved.members.get(options.user.id);
+        if (member !== undefined) {
+            if (!isAboveMember(guild, interaction.member, member)) {
+                return interaction.createMessage({
+                    content: `${config.emotes.error} You cannot ban this member.`,
+                    flags: MessageFlags.Ephemeral
+                });
+            }
+
+            const self = await this.client.api.guilds.getMember(interaction.guildID, this.client.applicationID);
+            if (!isAboveMember(guild, self as PartialGuildMember, member)) {
+                return interaction.createMessage({
+                    content: `${config.emotes.error} I cannot ban this member.`,
+                    flags: MessageFlags.Ephemeral
+                });
+            }
+        }
+
+        const tempBan = await this.module.tempBans.get(interaction.guildID, options.user.id);
+        const isBanned = member === undefined
+            && await this.module.isBanned(interaction.guildID, options.user.id);
+
+        if (tempBan !== null) {
+            if (duration === undefined) {
+                await this.module.tempBans.delete(interaction.guildID, options.user.id);
+            } else {
+                await this.module.tempBans.update(interaction.guildID, options.user.id, duration);
+            }
+        } else if (duration !== undefined) {
+            await this.module.tempBans.create(interaction.guildID, options.user.id, duration);
+        } else if (isBanned) {
+            return interaction.createMessage({
+                content: `${config.emotes.error} This user is already banned.`,
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
+        if (member !== undefined) {
+            try {
+                const channel = await this.client.api.users.createDM(options.user.id);
+                const fields = [{
+                    name: "**Reason**",
+                    value: options.reason
+                }];
+
+                if (duration !== undefined) {
+                    fields.push({
+                        name: "**Duration**",
+                        value: `Expires <t:${Math.trunc(((Date.now() / 1000) + duration))}:R>`
+                    });
+                }
+
+                await this.client.api.channels.createMessage(channel.id, {
+                    embeds: [{
+                        color: config.defaultColor,
+                        description: `${config.emotes.error} You have been banned from **${guild.name}**`,
+                        fields: fields
+                    }]
+                });
+            } catch (error: unknown) {
+                if (!(error instanceof DiscordAPIError) || error.code !== 50007) {
+                    this.client.logger.error(error);
+                }
+            }
+        }
+
+        if (!isBanned) {
+            try {
+                await this.client.api.guilds.banUser(interaction.guildID, options.user.id, {
+                    delete_message_seconds: options.delete ? 604800 : 0
+                }, {
+                    reason: options.reason
+                });
+            } catch (error: unknown) {
+                this.client.logger.error(error);
+
+                return interaction.createMessage({
+                    content: `${config.emotes.error} Failed to ban this member.`,
+                    flags: MessageFlags.Ephemeral
+                });
+            }
+        }
+
+        const entity = await this.module.cases.create({
+            creatorID: interaction.user.id,
+            guildID: interaction.guildID,
+            note: options.reason,
+            type: CaseType.Ban,
+            userID: options.user.id
+        });
+
+        await interaction.createMessage({
+            content: `${config.emotes.check} Case \`${entity.id}\` | Successfully banned \`${options.user.username}\`.`,
+            flags: MessageFlags.Ephemeral
+        });
+
+        const settings = await this.module.moderationSettings.getOrCreate(interaction.guildID);
+        await this.module.createLogMessage({
+            case: entity,
+            creator: interaction.user,
+            duration: duration,
+            reason: options.reason,
+            user: options.user
+        }, settings);
+    }
+}

--- a/apps/barry/src/modules/moderation/database.ts
+++ b/apps/barry/src/modules/moderation/database.ts
@@ -4,7 +4,8 @@ import type {
     CaseType,
     ModerationSettings,
     Prisma,
-    PrismaClient
+    PrismaClient,
+    TempBan
 } from "@prisma/client";
 
 /**
@@ -357,6 +358,96 @@ export class ModerationSettingsRepository {
             create: { ...settings, guildID },
             update: settings,
             where: { guildID }
+        });
+    }
+}
+
+/**
+ * Repository class for managing temporary bans.
+ */
+export class TempBanRepository {
+    /**
+     * The Prisma client used to interact with the database.
+     */
+    #prisma: PrismaClient;
+
+    /**
+     * Repository class for managing temporary bans.
+     *
+     * @param prisma The Prisma client used to interact with the database.
+     */
+    constructor(prisma: PrismaClient) {
+        this.#prisma = prisma;
+    }
+
+    /**
+     * Creates a new temporary ban.
+     *
+     * @param guildID The ID of the guild.
+     * @param userID The ID of the user.
+     * @param duration The duration of the ban in seconds.
+     * @returns The new temporary ban record.
+     */
+    async create(guildID: string, userID: string, duration: number): Promise<TempBan> {
+        const expiresAt = new Date(Date.now() + duration * 1000);
+        return this.#prisma.tempBan.create({
+            data: {
+                expiresAt,
+                guildID,
+                userID
+            }
+        });
+    }
+
+    /**
+     * Deletes a temporary ban.
+     *
+     * @param guildID The ID of the guild.
+     * @param userID The ID of the user.
+     * @returns The deleted temporary ban record.
+     */
+    async delete(guildID: string, userID: string): Promise<TempBan> {
+        return this.#prisma.tempBan.delete({
+            where: { guildID_userID: { guildID, userID } }
+        });
+    }
+
+    /**
+     * Retrieves a temporary ban for a user.
+     *
+     * @param guildID The ID of the guild.
+     * @param userID The ID of the user.
+     * @returns The temporary ban record, or null if not found.
+     */
+    async get(guildID: string, userID: string): Promise<TempBan | null> {
+        return this.#prisma.tempBan.findUnique({
+            where: { guildID_userID: { guildID, userID } }
+        });
+    }
+
+    /**
+     * Retrieves all expired temporary bans for the specified guild.
+     *
+     * @returns The expired temporary ban records.
+     */
+    async getExpired(): Promise<TempBan[]> {
+        return this.#prisma.tempBan.findMany({
+            where: { expiresAt: { lte: new Date() } }
+        });
+    }
+
+    /**
+     * Updates a temporary ban.
+     *
+     * @param guildID The ID of the guild.
+     * @param userID The ID of the user.
+     * @param duration The new duration of the ban in seconds.
+     * @returns The updated temporary ban record.
+     */
+    async update(guildID: string, userID: string, duration: number): Promise<TempBan> {
+        return this.#prisma.tempBan.update({
+            data: { expiresAt: new Date(Date.now() + duration * 1000) },
+            where: { guildID_userID: { guildID, userID } }
         });
     }
 }

--- a/apps/barry/tests/modules/moderation/commands/chatinput/ban/index.test.ts
+++ b/apps/barry/tests/modules/moderation/commands/chatinput/ban/index.test.ts
@@ -1,0 +1,429 @@
+import {
+    type Case,
+    type ModerationSettings,
+    type TempBan,
+    CaseType
+} from "@prisma/client";
+import { ApplicationCommandInteraction, AutocompleteInteraction } from "@barry/core";
+import { ApplicationCommandType, MessageFlags } from "@discordjs/core";
+import {
+    createMockApplicationCommandInteraction,
+    createMockAutocompleteInteraction,
+    mockChannel,
+    mockGuild,
+    mockInteractionMember,
+    mockMember,
+    mockMessage,
+    mockUser
+} from "@barry/testing";
+
+import { DiscordAPIError } from "@discordjs/rest";
+import { COMMON_SEVERE_REASONS } from "../../../../../../src/modules/moderation/constants.js";
+import { createMockApplication } from "../../../../../mocks/application.js";
+
+import BanCommand, { type BanOptions } from "../../../../../../src/modules/moderation/commands/chatinput/ban/index.js";
+import ModerationModule from "../../../../../../src/modules/moderation/index.js";
+import * as permissions from "../../../../../../src/modules/moderation/functions/permissions.js";
+
+describe("/ban", () => {
+    let command: BanCommand;
+    let interaction: ApplicationCommandInteraction;
+    let mockCase: Case;
+    let options: BanOptions;
+    let settings: ModerationSettings;
+
+    beforeEach(() => {
+        const client = createMockApplication();
+
+        const module = new ModerationModule(client);
+        command = new BanCommand(module);
+
+        const data = createMockApplicationCommandInteraction();
+        interaction = new ApplicationCommandInteraction(data, client, vi.fn());
+        if (interaction.data.isChatInput()) {
+            interaction.data.resolved.members.set("257522665437265920", mockInteractionMember);
+        }
+
+        mockCase = {
+            createdAt: new Date("1-1-2023"),
+            creatorID: mockUser.id,
+            guildID: mockGuild.id,
+            id: 34,
+            type: CaseType.Ban,
+            userID: "257522665437265920"
+        };
+        options = {
+            user: {
+                ...mockUser,
+                id: "257522665437265920"
+            },
+            reason: "Rude!"
+        };
+        settings = {
+            channelID: "30527482987641765",
+            dwcDays: 7,
+            dwcRoleID: null,
+            enabled: true,
+            guildID: "68239102456844360"
+        };
+
+        module.createLogMessage = vi.fn();
+        vi.spyOn(client.api.channels, "createMessage").mockResolvedValue(mockMessage);
+        vi.spyOn(client.api.guilds, "get").mockResolvedValue(mockGuild);
+        vi.spyOn(client.api.guilds, "getMember").mockResolvedValue(mockMember);
+        vi.spyOn(client.api.guilds, "banUser").mockResolvedValue(undefined);
+        vi.spyOn(client.api.users, "createDM").mockResolvedValue({ ...mockChannel, position: 0 });
+        vi.spyOn(module.cases, "create").mockResolvedValue(mockCase);
+        vi.spyOn(module.moderationSettings, "getOrCreate").mockResolvedValue(settings);
+    });
+
+    describe("execute", () => {
+        describe("Validation", () => {
+            it("should ignore if the interaction was sent outside a guild", async () => {
+                delete interaction.guildID;
+
+                await command.execute(interaction, options);
+
+                expect(interaction.acknowledged).toBe(false);
+            });
+
+            it("should show an error message if the moderator tries to warn themselves", async () => {
+                const createSpy = vi.spyOn(interaction, "createMessage");
+                options.user.id = interaction.user.id;
+
+                await command.execute(interaction, options);
+
+                expect(createSpy).toHaveBeenCalledOnce();
+                expect(createSpy).toHaveBeenCalledWith({
+                    content: expect.stringContaining("You cannot ban yourself."),
+                    flags: MessageFlags.Ephemeral
+                });
+            });
+
+            it("should show an error message if the moderator tries to warn the bot", async () => {
+                const createSpy = vi.spyOn(interaction, "createMessage");
+                options.user.id = command.client.applicationID;
+
+                await command.execute(interaction, options);
+
+                expect(createSpy).toHaveBeenCalledOnce();
+                expect(createSpy).toHaveBeenCalledWith({
+                    content: expect.stringContaining("Your attempt to ban me has been classified as a failed comedy show audition."),
+                    flags: MessageFlags.Ephemeral
+                });
+            });
+
+            it("should show an error message if the moderator is below the target", async () => {
+                vi.spyOn(permissions, "isAboveMember").mockReturnValue(false);
+                const createSpy = vi.spyOn(interaction, "createMessage");
+
+                await command.execute(interaction, options);
+
+                expect(createSpy).toHaveBeenCalledOnce();
+                expect(createSpy).toHaveBeenCalledWith({
+                    content: expect.stringContaining("You cannot ban this member."),
+                    flags: MessageFlags.Ephemeral
+                });
+            });
+
+            it("should show an error message if the bot is below the target", async () => {
+                vi.spyOn(permissions, "isAboveMember")
+                    .mockReturnValueOnce(true)
+                    .mockReturnValue(false);
+                const createSpy = vi.spyOn(interaction, "createMessage");
+
+                await command.execute(interaction, options);
+
+                expect(createSpy).toHaveBeenCalledOnce();
+                expect(createSpy).toHaveBeenCalledWith({
+                    content: expect.stringContaining("I cannot ban this member."),
+                    flags: MessageFlags.Ephemeral
+                });
+            });
+
+            it("should show an error message if the duration is less than 60 seconds", async () => {
+                const createSpy = vi.spyOn(interaction, "createMessage");
+                options.duration = "30s";
+
+                await command.execute(interaction, options);
+
+                expect(createSpy).toHaveBeenCalledOnce();
+                expect(createSpy).toHaveBeenCalledWith({
+                    content: expect.stringContaining("The duration must at least be 60 seconds."),
+                    flags: MessageFlags.Ephemeral
+                });
+            });
+
+            it("should show an error message if the duration is more than 28 days", async () => {
+                const createSpy = vi.spyOn(interaction, "createMessage");
+                options.duration = "30d";
+
+                await command.execute(interaction, options);
+
+                expect(createSpy).toHaveBeenCalledOnce();
+                expect(createSpy).toHaveBeenCalledWith({
+                    content: expect.stringContaining("The duration must not exceed 28 days."),
+                    flags: MessageFlags.Ephemeral
+                });
+            });
+        });
+
+        describe("Error Handling", () => {
+            it("should log an error if the direct message fails due to an unknown error", async () => {
+                const error = new Error("Oh no!");
+                vi.spyOn(command.client.api.channels, "createMessage").mockRejectedValueOnce(error);
+                vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+
+                await command.execute(interaction, options);
+
+                expect(command.client.logger.error).toHaveBeenCalledOnce();
+                expect(command.client.logger.error).toHaveBeenCalledWith(error);
+            });
+
+            it("should ignore an error if the direct message fails due to the user disabling DMs", async () => {
+                const response = {
+                    code: 50007,
+                    message: "Cannot send messages to this user"
+                };
+
+                const error = new DiscordAPIError(response, 50007, 200, "GET", "", {});
+                vi.spyOn(command.client.api.channels, "createMessage").mockRejectedValueOnce(error);
+                vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+
+                await command.execute(interaction, options);
+
+                expect(command.client.logger.error).not.toHaveBeenCalledOnce();
+            });
+
+            it("should log an error if the ban fails due to an unknown error", async () => {
+                const error = new Error("Oh no!");
+                vi.spyOn(command.client.api.guilds, "banUser").mockRejectedValueOnce(error);
+                vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+
+                await command.execute(interaction, options);
+
+                expect(command.client.logger.error).toHaveBeenCalledOnce();
+                expect(command.client.logger.error).toHaveBeenCalledWith(error);
+            });
+        });
+
+        describe("Temporarily Ban", () => {
+            let tempBan: TempBan;
+
+            beforeEach(() => {
+                tempBan = {
+                    expiresAt: new Date("1-1-2023"),
+                    guildID: mockGuild.id,
+                    userID: options.user.id
+                };
+
+                vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+                vi.spyOn(command.module.tempBans, "get").mockResolvedValueOnce(tempBan);
+            });
+
+            it("should delete an existing scheduled unban if the ban is permanent", async () => {
+                const deleteSpy = vi.spyOn(command.module.tempBans, "delete");
+
+                await command.execute(interaction, options);
+
+                expect(deleteSpy).toHaveBeenCalledOnce();
+                expect(deleteSpy).toHaveBeenCalledWith(mockGuild.id, options.user.id);
+            });
+
+            it("should create a new scheduled unban if the ban is temporary", async () => {
+                vi.spyOn(command.module.tempBans, "get").mockResolvedValueOnce(null);
+                const createSpy = vi.spyOn(command.module.tempBans, "create");
+                options.duration = "1d";
+
+                await command.execute(interaction, options);
+
+                expect(createSpy).toHaveBeenCalledOnce();
+                expect(createSpy).toHaveBeenCalledWith(mockGuild.id, options.user.id, 86400);
+            });
+
+            it("should update an existing scheduled unban if the ban is temporary", async () => {
+                const updateSpy = vi.spyOn(command.module.tempBans, "update");
+                options.duration = "1d";
+
+                await command.execute(interaction, options);
+
+                expect(updateSpy).toHaveBeenCalledOnce();
+                expect(updateSpy).toHaveBeenCalledWith(mockGuild.id, options.user.id, 86400);
+            });
+
+            it("should show an error if the ban is permanently and the user is already banned indefinitely", async () => {
+                if (interaction.data.isChatInput()) {
+                    interaction.data.resolved.members.delete(options.user.id);
+                }
+                vi.spyOn(command.module.tempBans, "get").mockResolvedValueOnce(null);
+                vi.spyOn(command.module, "isBanned").mockResolvedValueOnce(true);
+                const createSpy = vi.spyOn(interaction, "createMessage");
+
+                await command.execute(interaction, options);
+
+                expect(createSpy).toHaveBeenCalledOnce();
+                expect(createSpy).toHaveBeenCalledWith({
+                    content: expect.stringContaining("This user is already banned."),
+                    flags: MessageFlags.Ephemeral
+                });
+            });
+        });
+
+        describe("Notify User", () => {
+            it("should send a direct message to the target if they are still in the guild", async () => {
+                vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+                const createSpy = vi.spyOn(command.client.api.channels, "createMessage");
+
+                await command.execute(interaction, options);
+
+                expect(createSpy).toHaveBeenCalledOnce();
+                expect(createSpy).toHaveBeenCalledWith(mockChannel.id, {
+                    embeds: [{
+                        color: expect.any(Number),
+                        description: expect.stringContaining("You have been banned from **Barry's Server**"),
+                        fields: [{
+                            name: "**Reason**",
+                            value: options.reason
+                        }]
+                    }]
+                });
+            });
+
+            it("should not send a direct message to the target if they are not in the guild", async () => {
+                if (interaction.data.isChatInput()) {
+                    interaction.data.resolved.members.delete(options.user.id);
+                }
+                vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+                const createSpy = vi.spyOn(command.client.api.channels, "createMessage");
+
+                await command.execute(interaction, options);
+
+                expect(createSpy).not.toHaveBeenCalled();
+            });
+        });
+
+        describe("Ban User", () => {
+            it("should ban the user from the guild if they aren't yet", async () => {
+                vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+                const banSpy = vi.spyOn(command.client.api.guilds, "banUser");
+
+                await command.execute(interaction, options);
+
+                expect(banSpy).toHaveBeenCalledOnce();
+                expect(banSpy).toHaveBeenCalledWith(mockGuild.id, options.user.id, {
+                    delete_message_seconds: 0
+                }, {
+                    reason: options.reason
+                });
+            });
+
+            it("should delete the messages of the user if the 'delete' option is enabled", async () => {
+                vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+                const banSpy = vi.spyOn(command.client.api.guilds, "banUser");
+
+                options.delete = true;
+                await command.execute(interaction, options);
+
+                expect(banSpy).toHaveBeenCalledOnce();
+                expect(banSpy).toHaveBeenCalledWith(mockGuild.id, options.user.id, {
+                    delete_message_seconds: 604800
+                }, {
+                    reason: options.reason
+                });
+            });
+
+            it("should not ban the user if they are already banned", async () => {
+                if (interaction.data.isChatInput()) {
+                    interaction.data.resolved.members.delete(options.user.id);
+                }
+                vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+                vi.spyOn(command.module, "isBanned").mockResolvedValueOnce(true);
+                const banSpy = vi.spyOn(command.client.api.guilds, "banUser");
+
+                await command.execute(interaction, options);
+
+                expect(banSpy).not.toHaveBeenCalled();
+            });
+        });
+
+        it("should create a new case in the database", async () => {
+            vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+            const createSpy = vi.spyOn(command.module.cases, "create");
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith({
+                creatorID: interaction.user.id,
+                guildID: interaction.guildID,
+                note: options.reason,
+                type: CaseType.Ban,
+                userID: options.user.id
+            });
+        });
+
+        it("should show a success message to the moderator", async () => {
+            vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+            const createSpy = vi.spyOn(interaction, "createMessage");
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith({
+                content: expect.stringContaining(`Case \`34\` | Successfully banned \`${options.user.username}\``),
+                flags: MessageFlags.Ephemeral
+            });
+        });
+
+        it("should log the case in the configured log channel", async () => {
+            vi.spyOn(permissions, "isAboveMember").mockReturnValue(true);
+            const createSpy = vi.spyOn(command.module, "createLogMessage");
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith({
+                case: mockCase,
+                creator: interaction.user,
+                reason: options.reason,
+                user: options.user
+            }, settings);
+        });
+    });
+
+    describe("Autocomplete 'reason'", () => {
+        it("should show a predefined list of reasons if no value is provided", async () => {
+            const data = createMockAutocompleteInteraction({
+                id: "49072635294295155",
+                name: "ban",
+                options: [],
+                type: ApplicationCommandType.ChatInput
+            });
+            const interaction = new AutocompleteInteraction(data, command.client, vi.fn());
+
+            const result = await command.options[1].autocomplete?.("" as never, interaction);
+
+            expect(result).toEqual(COMMON_SEVERE_REASONS.map((x) => ({ name: x, value: x })));
+        });
+
+        it("should show a matching predefined option if the option starts with the value", async () => {
+            const data = createMockAutocompleteInteraction({
+                id: "49072635294295155",
+                name: "ban",
+                options: [],
+                type: ApplicationCommandType.ChatInput
+            });
+            const interaction = new AutocompleteInteraction(data, command.client, vi.fn());
+
+            const result = await command.options[1].autocomplete?.(
+                COMMON_SEVERE_REASONS[0].slice(0, 5) as never,
+                interaction
+            );
+
+            expect(result).toEqual([{
+                name: COMMON_SEVERE_REASONS[0],
+                value: COMMON_SEVERE_REASONS[0]
+            }]);
+        });
+    });
+});

--- a/apps/barry/tests/modules/moderation/database.test.ts
+++ b/apps/barry/tests/modules/moderation/database.test.ts
@@ -2,13 +2,15 @@ import {
     type Case,
     type CaseNote,
     type ModerationSettings,
+    type TempBan,
     CaseType,
     Prisma
 } from "@prisma/client";
 import {
     CaseNoteRepository,
     CaseRepository,
-    ModerationSettingsRepository
+    ModerationSettingsRepository,
+    TempBanRepository
 } from "../../../src/modules/moderation/database.js";
 import { prisma } from "../../mocks/index.js";
 
@@ -470,6 +472,128 @@ describe("ModerationSettingsRepository", () => {
                     channelID: "30527482987641765"
                 },
                 where: { guildID }
+            });
+        });
+    });
+});
+
+describe("TempBanRepository", () => {
+    const guildID = "68239102456844360";
+    const userID = "257522665437265920";
+
+    let repository: TempBanRepository;
+    let mockTempBan: TempBan;
+
+    beforeEach(() => {
+        vi.useFakeTimers().setSystemTime("01-01-2023");
+
+        repository = new TempBanRepository(prisma);
+        mockTempBan = {
+            expiresAt: new Date(Date.now() + 604800000),
+            guildID: guildID,
+            userID: userID
+        };
+    });
+
+    describe("create", () => {
+        it("should create a new temp ban record", async () => {
+            await repository.create(guildID, userID, 604800);
+
+            expect(prisma.tempBan.create).toHaveBeenCalledOnce();
+            expect(prisma.tempBan.create).toHaveBeenCalledWith({
+                data: {
+                    expiresAt: new Date(Date.now() + 604800000),
+                    guildID: guildID,
+                    userID: userID
+                }
+            });
+        });
+    });
+
+    describe("delete", () => {
+        it("should delete the specified temp ban record", async () => {
+            await repository.delete(guildID, userID);
+
+            expect(prisma.tempBan.delete).toHaveBeenCalledOnce();
+            expect(prisma.tempBan.delete).toHaveBeenCalledWith({
+                where: {
+                    guildID_userID: {
+                        guildID,
+                        userID
+                    }
+                }
+            });
+        });
+    });
+
+    describe("get", () => {
+        it("should return the specified temp ban record", async () => {
+            vi.mocked(prisma.tempBan.findUnique).mockResolvedValue(mockTempBan);
+
+            const entity = await repository.get(guildID, userID);
+
+            expect(entity).toEqual(mockTempBan);
+            expect(prisma.tempBan.findUnique).toHaveBeenCalledOnce();
+            expect(prisma.tempBan.findUnique).toHaveBeenCalledWith({
+                where: {
+                    guildID_userID: {
+                        guildID,
+                        userID
+                    }
+                }
+            });
+        });
+
+        it("should return null if the temp ban record does not exist", async () => {
+            vi.mocked(prisma.tempBan.findUnique).mockResolvedValue(null);
+
+            const entity = await repository.get(guildID, userID);
+
+            expect(entity).toEqual(null);
+        });
+    });
+
+    describe("getExpired", () => {
+        it("should return all expired temp ban records", async () => {
+            vi.mocked(prisma.tempBan.findMany).mockResolvedValue([mockTempBan]);
+
+            const entities = await repository.getExpired();
+
+            expect(entities).toEqual([mockTempBan]);
+            expect(prisma.tempBan.findMany).toHaveBeenCalledOnce();
+            expect(prisma.tempBan.findMany).toHaveBeenCalledWith({
+                where: {
+                    expiresAt: {
+                        lte: new Date()
+                    }
+                }
+            });
+        });
+
+        it("should return an empty array if no temp ban records are expired", async () => {
+            vi.mocked(prisma.tempBan.findMany).mockResolvedValue([]);
+
+            const entities = await repository.getExpired();
+
+            expect(entities).toEqual([]);
+        });
+    });
+
+    describe("update", () => {
+        it("should update the specified temp ban record", async () => {
+            await repository.update(guildID, userID, 604800);
+
+            expect(prisma.tempBan.update).toHaveBeenCalledOnce();
+            expect(prisma.tempBan.update).toHaveBeenCalledWith({
+                data: {
+                    expiresAt: new Date(Date.now() + 604800000)
+                },
+                where: {
+                    guildID_userID: {
+                        guildID,
+                        userID
+                    }
+                }
             });
         });
     });

--- a/apps/barry/tests/modules/moderation/index.test.ts
+++ b/apps/barry/tests/modules/moderation/index.test.ts
@@ -1,14 +1,16 @@
+import { type ModerationSettings, CaseType } from "@prisma/client";
 import type { CaseLogOptions } from "../../../dist/modules/moderation/functions/getLogContent.js";
-import type { ModerationSettings } from "@prisma/client";
 
 import {
     CaseNoteRepository,
     CaseRepository,
-    ModerationSettingsRepository
+    ModerationSettingsRepository,
+    TempBanRepository
 } from "../../../src/modules/moderation/database.js";
+import { mockGuild, mockUser } from "@barry/testing";
 import { DiscordAPIError } from "@discordjs/rest";
+import { Module } from "@barry/core";
 import { createMockApplication } from "../../mocks/application.js";
-import { mockGuild } from "@barry/testing";
 
 import ModerationModule from "../../../src/modules/moderation/index.js";
 import * as content from "../../../src/modules/moderation/functions/getLogContent.js";
@@ -39,6 +41,98 @@ describe("ModerationModule", () => {
             expect(module.caseNotes).toBeInstanceOf(CaseNoteRepository);
             expect(module.cases).toBeInstanceOf(CaseRepository);
             expect(module.moderationSettings).toBeInstanceOf(ModerationSettingsRepository);
+            expect(module.tempBans).toBeInstanceOf(TempBanRepository);
+        });
+    });
+
+    describe("checkExpiredBans", () => {
+        beforeEach(() => {
+            module.createLogMessage = vi.fn();
+            vi.spyOn(module.client.api.guilds, "unbanUser").mockResolvedValue();
+            vi.spyOn(module.client.api.users, "get")
+                .mockResolvedValueOnce({ ...mockUser, id: module.client.applicationID })
+                .mockResolvedValue(mockUser);
+
+            vi.spyOn(module.cases, "create").mockResolvedValue({
+                createdAt: new Date(),
+                creatorID: module.client.applicationID,
+                guildID: "68239102456844360",
+                id: 1,
+                type: CaseType.Unban,
+                userID: "30527482987641765"
+            });
+            vi.spyOn(module.moderationSettings, "getOrCreate").mockResolvedValue(settings);
+            vi.spyOn(module.tempBans, "getExpired").mockResolvedValue([{
+                expiresAt: new Date(),
+                guildID: "68239102456844360",
+                userID: "30527482987641765"
+            }]);
+
+            settings.channelID = "30527482987641765";
+        });
+
+        it("should unban users whose temporary ban has expired", async () => {
+            await module.checkExpiredBans();
+
+            expect(module.client.api.guilds.unbanUser).toHaveBeenCalledOnce();
+            expect(module.client.api.guilds.unbanUser).toHaveBeenCalledWith("68239102456844360", "30527482987641765");
+            expect(module.tempBans.getExpired).toHaveBeenCalledOnce();
+            expect(module.tempBans.getExpired).toHaveBeenCalledWith();
+        });
+
+        it("should delete the temporary ban from the database", async () => {
+            const deleteSpy = vi.spyOn(module.tempBans, "delete");
+
+            await module.checkExpiredBans();
+
+            expect(deleteSpy).toHaveBeenCalledOnce();
+            expect(deleteSpy).toHaveBeenCalledWith("68239102456844360", "30527482987641765");
+        });
+
+        it("should log an error if the unban fails due to an unknown error", async () => {
+            const error = new Error("Oh no!");
+            vi.spyOn(module.client.api.guilds, "unbanUser").mockRejectedValue(error);
+
+            await module.checkExpiredBans();
+
+            expect(module.client.logger.error).toHaveBeenCalledOnce();
+            expect(module.client.logger.error).toHaveBeenCalledWith(error);
+        });
+
+        it("should not log an error if the unban fails due to the user not being banned", async () => {
+            const response = {
+                code: 10026,
+                message: "Unknown Ban"
+            };
+
+            const error = new DiscordAPIError(response, 10026, 404, "DELETE", "", {});
+            vi.spyOn(module.client.api.guilds, "unbanUser").mockRejectedValue(error);
+
+            await module.checkExpiredBans();
+
+            expect(module.client.logger.error).not.toHaveBeenCalled();
+        });
+
+        it("should do nothing if there are no expired bans", async () => {
+            vi.spyOn(module.tempBans, "getExpired").mockResolvedValue([]);
+
+            await module.checkExpiredBans();
+
+            expect(module.client.api.guilds.unbanUser).not.toHaveBeenCalled();
+        });
+
+        it("should create a case for the unban", async () => {
+            await module.checkExpiredBans();
+
+            expect(module.createLogMessage).toHaveBeenCalledOnce();
+            expect(module.cases.create).toHaveBeenCalledOnce();
+            expect(module.cases.create).toHaveBeenCalledWith({
+                creatorID: module.client.applicationID,
+                guildID: "68239102456844360",
+                note: "Temporary ban expired.",
+                type: CaseType.Unban,
+                userID: "30527482987641765"
+            });
         });
     });
 
@@ -96,6 +190,60 @@ describe("ModerationModule", () => {
 
             expect(module.client.logger.error).toHaveBeenCalledOnce();
             expect(module.client.logger.error).toHaveBeenCalledWith(error);
+        });
+    });
+
+    describe("initialize", () => {
+        it("should call super.initialize", async () => {
+            const initSpy = vi.spyOn(Module.prototype, "initialize").mockResolvedValue();
+
+            await module.initialize();
+
+            expect(initSpy).toHaveBeenCalledOnce();
+        });
+
+        it("should set up the interval to check for expired bans", async () => {
+            vi.useFakeTimers();
+            const checkSpy = vi.spyOn(module, "checkExpiredBans").mockResolvedValue();
+            const intervalSpy = vi.spyOn(global, "setInterval");
+
+            await module.initialize();
+            vi.advanceTimersByTime(600000);
+
+            expect(intervalSpy).toHaveBeenCalledOnce();
+            expect(intervalSpy).toHaveBeenCalledWith(expect.any(Function), 600000);
+            expect(checkSpy).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe("isBanned", () => {
+        it("should return true if the user is banned", async () => {
+            const getSpy = vi.spyOn(module.client.api.guilds, "getMemberBan").mockResolvedValue({
+                reason: "Temporary ban expired.",
+                user: mockUser
+            });
+
+            const banned = await module.isBanned("68239102456844360", "30527482987641765");
+
+            expect(getSpy).toHaveBeenCalledOnce();
+            expect(getSpy).toHaveBeenCalledWith("68239102456844360", "30527482987641765");
+            expect(banned).toBe(true);
+        });
+
+        it("should return false if the user is not banned", async () => {
+            const response = {
+                code: 10026,
+                message: "Unknown Ban"
+            };
+
+            const error = new DiscordAPIError(response, 10026, 404, "GET", "", {});
+            const getSpy = vi.spyOn(module.client.api.guilds, "getMemberBan").mockRejectedValue(error);
+
+            const banned = await module.isBanned("68239102456844360", "30527482987641765");
+
+            expect(getSpy).toHaveBeenCalledOnce();
+            expect(getSpy).toHaveBeenCalledWith("68239102456844360", "30527482987641765");
+            expect(banned).toBe(false);
         });
     });
 


### PR DESCRIPTION
Closes #14, part of #24.
- Adds a `/ban` command
- Supports temporary bans (scheduled unbans)
