### PR TITLE
feat: implement note command

### DIFF
--- a/apps/barry/src/modules/moderation/commands/chatinput/note/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/note/index.ts
@@ -1,0 +1,92 @@
+import {
+    type APIUser,
+    MessageFlags,
+    PermissionFlagsBits
+} from "@discordjs/core";
+import {
+    type ApplicationCommandInteraction,
+    SlashCommand,
+    SlashCommandOptionBuilder
+} from "@barry/core";
+import type ModerationModule from "../../../index.js";
+
+import { CaseType } from "@prisma/client";
+import config from "../../../../../config.js";
+
+/**
+ * Options for the note command.
+ */
+export interface NoteOptions {
+    /**
+     * The content of the note.
+     */
+    note: string;
+
+    /**
+     * The user to add a note to.
+     */
+    user: APIUser;
+}
+
+/**
+ * Represents a slash command that adds a note to a user.
+ */
+export default class extends SlashCommand<ModerationModule> {
+    /**
+     * Represents a slash command that adds a note to a user.
+     *
+     * @param module The module this command belongs to.
+     */
+    constructor(module: ModerationModule) {
+        super(module, {
+            name: "note",
+            description: "Adds a note to a user.",
+            defaultMemberPermissions: PermissionFlagsBits.ModerateMembers,
+            guildOnly: true,
+            options: {
+                user: SlashCommandOptionBuilder.user({
+                    description: "The user to add a note to.",
+                    required: true
+                }),
+                note: SlashCommandOptionBuilder.string({
+                    description: "The content of the note.",
+                    maximum: 200,
+                    required: true
+                })
+            }
+        });
+    }
+
+    /**
+     * Adds a note to a user.
+     *
+     * @param interaction The interaction that triggered the command.
+     * @param options The options for the command.
+     */
+    async execute(interaction: ApplicationCommandInteraction, options: NoteOptions): Promise<void> {
+        if (!interaction.isInvokedInGuild()) {
+            return;
+        }
+
+        const entity = await this.module.cases.create({
+            creatorID: interaction.user.id,
+            guildID: interaction.guildID,
+            note: options.note,
+            type: CaseType.Note,
+            userID: options.user.id
+        });
+
+        await interaction.createMessage({
+            content: `${config.emotes.check} Case \`${entity.id}\` | Successfully added a note to \`${options.user.username}\`.`,
+            flags: MessageFlags.Ephemeral
+        });
+
+        const settings = await this.module.moderationSettings.getOrCreate(interaction.guildID);
+        await this.module.createLogMessage({
+            case: entity,
+            creator: interaction.user,
+            reason: options.note,
+            user: options.user
+        }, settings);
+    }
+}

--- a/apps/barry/src/modules/moderation/commands/chatinput/warn/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/warn/index.ts
@@ -32,7 +32,7 @@ export interface WarnOptions {
  */
 export default class extends SlashCommand<ModerationModule> {
     /**
-     * Represents the constructor of this slash command.
+     * Represents a slash command that warns a user.
      *
      * @param module The module this command belongs to.
      */

--- a/apps/barry/tests/modules/moderation/commands/chatinput/note/index.test.ts
+++ b/apps/barry/tests/modules/moderation/commands/chatinput/note/index.test.ts
@@ -1,0 +1,108 @@
+import {
+    type Case,
+    type ModerationSettings,
+    CaseType
+} from "@prisma/client";
+import {
+    createMockApplicationCommandInteraction,
+    mockGuild,
+    mockUser
+} from "@barry/testing";
+import { ApplicationCommandInteraction } from "@barry/core";
+import { MessageFlags } from "@discordjs/core";
+import { createMockApplication } from "../../../../../mocks/application.js";
+
+import NoteCommand, { type NoteOptions } from "../../../../../../src/modules/moderation/commands/chatinput/note/index.js";
+import ModerationModule from "../../../../../../src/modules/moderation/index.js";
+
+describe("/note", () => {
+    let command: NoteCommand;
+    let interaction: ApplicationCommandInteraction;
+    let mockCase: Case;
+    let options: NoteOptions;
+    let settings: ModerationSettings;
+
+    beforeEach(() => {
+        const client = createMockApplication();
+        const module = new ModerationModule(client);
+        command = new NoteCommand(module);
+
+        const data = createMockApplicationCommandInteraction();
+        interaction = new ApplicationCommandInteraction(data, client, vi.fn());
+
+        mockCase = {
+            createdAt: new Date("1-1-2023"),
+            creatorID: mockUser.id,
+            guildID: mockGuild.id,
+            id: 34,
+            type: CaseType.Note,
+            userID: "257522665437265920"
+        };
+        options = {
+            note: "This is a note.",
+            user: {
+                ...mockUser,
+                id: "257522665437265920"
+            }
+        };
+        settings = {
+            channelID: "30527482987641765",
+            dwcDays: 7,
+            dwcRoleID: null,
+            enabled: true,
+            guildID: "68239102456844360"
+        };
+
+        module.createLogMessage = vi.fn();
+        vi.spyOn(module.cases, "create").mockResolvedValue(mockCase);
+        vi.spyOn(module.moderationSettings, "getOrCreate").mockResolvedValue(settings);
+    });
+
+    describe("execute", () => {
+        it("should create a note case", async () => {
+            await command.execute(interaction, options);
+
+            expect(command.module.cases.create).toHaveBeenCalledOnce();
+            expect(command.module.cases.create).toHaveBeenCalledWith({
+                creatorID: interaction.user.id,
+                guildID: interaction.guildID,
+                note: options.note,
+                type: CaseType.Note,
+                userID: options.user.id
+            });
+        });
+
+        it("should create a log message", async () => {
+            await command.execute(interaction, options);
+
+            expect(command.module.createLogMessage).toHaveBeenCalledOnce();
+            expect(command.module.createLogMessage).toHaveBeenCalledWith({
+                case: mockCase,
+                creator: interaction.user,
+                reason: options.note,
+                user: options.user
+            }, settings);
+        });
+
+        it("should send a success message", async () => {
+            const createSpy = vi.spyOn(interaction, "createMessage");
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith({
+                content: expect.stringContaining(`Case \`34\` | Successfully added a note to \`${mockUser.username}\`.`),
+                flags: MessageFlags.Ephemeral
+            });
+        });
+
+        it("should ignore if the interaction was sent outside a guild", async () => {
+            const createSpy = vi.spyOn(interaction, "createMessage");
+            delete interaction.guildID;
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).not.toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
Closes #18, part of #24.
- Adds a `/note` command. Has no functionality other than creating a case on a user, useful to share information about users.