### PR TITLE
feat: implement unmute command

### DIFF
--- a/apps/barry/src/modules/moderation/commands/chatinput/mute/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/mute/index.ts
@@ -131,14 +131,6 @@ export default class extends SlashCommand<ModerationModule> {
             });
         }
 
-        await this.module.notifyUser({
-            duration: duration,
-            guild: guild,
-            reason: options.reason,
-            type: CaseType.Mute,
-            userID: options.member.user.id
-        });
-
         try {
             await this.client.api.guilds.editMember(interaction.guildID, options.member.user.id, {
                 communication_disabled_until: new Date(Date.now() + 1000 * duration).toISOString()
@@ -151,6 +143,14 @@ export default class extends SlashCommand<ModerationModule> {
                 flags: MessageFlags.Ephemeral
             });
         }
+
+        await this.module.notifyUser({
+            duration: duration,
+            guild: guild,
+            reason: options.reason,
+            type: CaseType.Mute,
+            userID: options.member.user.id
+        });
 
         const entity = await this.module.cases.create({
             creatorID: interaction.user.id,

--- a/apps/barry/src/modules/moderation/commands/chatinput/unmute/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/unmute/index.ts
@@ -1,0 +1,117 @@
+import {
+    type ApplicationCommandInteraction,
+    SlashCommand,
+    SlashCommandOptionBuilder
+} from "@barry/core";
+import type { PartialGuildMember } from "../../../functions/permissions.js";
+import type ModerationModule from "../../../index.js";
+
+import { MessageFlags, PermissionFlagsBits } from "@discordjs/core";
+import { CaseType } from "@prisma/client";
+import config from "../../../../../config.js";
+
+/**
+ * Options for the unmute command.
+ */
+export interface UnmuteOptions {
+    /**
+     * The member to unmute.
+     */
+    member: PartialGuildMember;
+
+    /**
+     * The reason for the unmute.
+     */
+    reason: string;
+}
+
+/**
+ * Represents a slash command that unmutes a user.
+ */
+export default class extends SlashCommand<ModerationModule> {
+    /**
+     * Represents a slash command that unmutes a user.
+     *
+     * @param module The module this command belongs to.
+     */
+    constructor(module: ModerationModule) {
+        super(module, {
+            name: "unmute",
+            description: "Unmute a member.",
+            appPermissions: PermissionFlagsBits.ModerateMembers,
+            defaultMemberPermissions: PermissionFlagsBits.ModerateMembers,
+            guildOnly: true,
+            options: {
+                member: SlashCommandOptionBuilder.member({
+                    description: "The member to unmute.",
+                    required: true
+                }),
+                reason: SlashCommandOptionBuilder.string({
+                    description: "The reason for the unmute.",
+                    required: true
+                })
+            }
+        });
+    }
+
+    /**
+     * Unmutes a member.
+     *
+     * @param interaction The interaction that triggered this command.
+     * @param options The options for the command.
+     */
+    async execute(interaction: ApplicationCommandInteraction, options: UnmuteOptions): Promise<void> {
+        if (!interaction.isInvokedInGuild()) {
+            return;
+        }
+
+        if (typeof options.member.communication_disabled_until !== "string") {
+            return interaction.createMessage({
+                content: `${config.emotes.error} That member is not muted`,
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
+        try {
+            await this.client.api.guilds.editMember(interaction.guildID, options.member.user.id, {
+                communication_disabled_until: null
+            });
+        } catch (error: unknown) {
+            this.client.logger.error(error);
+
+            return interaction.createMessage({
+                content: `${config.emotes.error} Failed to unmute this member.`,
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
+        const guild = await this.client.api.guilds.get(interaction.guildID);
+        await this.module.notifyUser({
+            guild: guild,
+            reason: options.reason,
+            type: CaseType.Unmute,
+            userID: options.member.user.id
+        });
+
+        const entity = await this.module.cases.create({
+            creatorID: interaction.user.id,
+            guildID: interaction.guildID,
+            note: options.reason,
+            type: CaseType.Unmute,
+            userID: options.member.user.id
+        });
+
+        await interaction.createMessage({
+            content: `${config.emotes.check} Case \`${entity.id}\` | Successfully unmuted \`${options.member.user.username}\`.`,
+            flags: MessageFlags.Ephemeral
+        });
+
+        const settings = await this.module.moderationSettings.getOrCreate(interaction.guildID);
+        await this.module.createLogMessage({
+            case: entity,
+            creator: interaction.user,
+            reason: options.reason,
+            user: options.member.user
+        }, settings);
+    }
+}

--- a/apps/barry/tests/modules/moderation/commands/chatinput/unmute/index.test.ts
+++ b/apps/barry/tests/modules/moderation/commands/chatinput/unmute/index.test.ts
@@ -1,0 +1,139 @@
+import {
+    type Case,
+    type ModerationSettings,
+    CaseType
+} from "@prisma/client";
+import {
+    createMockApplicationCommandInteraction,
+    mockGuild,
+    mockMember,
+    mockUser
+} from "@barry/testing";
+
+import { ApplicationCommandInteraction } from "@barry/core";
+import { MessageFlags } from "@discordjs/core";
+import { createMockApplication } from "../../../../../mocks/index.js";
+
+import UnmuteCommand, { type UnmuteOptions } from "../../../../../../src/modules/moderation/commands/chatinput/unmute/index.js";
+import ModerationModule from "../../../../../../src/modules/moderation/index.js";
+
+describe("/unmute", () => {
+    let command: UnmuteCommand;
+    let interaction: ApplicationCommandInteraction;
+    let mockCase: Case;
+    let options: UnmuteOptions;
+    let settings: ModerationSettings;
+
+    beforeEach(() => {
+        const client = createMockApplication();
+        const module = new ModerationModule(client);
+        command = new UnmuteCommand(module);
+
+        const data = createMockApplicationCommandInteraction();
+        interaction = new ApplicationCommandInteraction(data, client, vi.fn());
+
+        mockCase = {
+            createdAt: new Date("1-1-2023"),
+            creatorID: mockUser.id,
+            guildID: mockGuild.id,
+            id: 34,
+            type: CaseType.Unmute,
+            userID: "257522665437265920"
+        };
+        options = {
+            member: {
+                ...mockMember,
+                communication_disabled_until: new Date("1-1-2023").toISOString(),
+                user: {
+                    ...mockUser,
+                    id: "257522665437265920"
+                }
+            },
+            reason: "Rude!"
+        };
+        settings = {
+            channelID: "30527482987641765",
+            dwcDays: 7,
+            dwcRoleID: null,
+            enabled: true,
+            guildID: "68239102456844360"
+        };
+
+        module.createLogMessage = vi.fn();
+        module.notifyUser = vi.fn();
+        vi.spyOn(client.api.guilds, "editMember").mockResolvedValue(mockMember);
+        vi.spyOn(client.api.guilds, "get").mockResolvedValue(mockGuild);
+        vi.spyOn(module.cases, "create").mockResolvedValue(mockCase);
+        vi.spyOn(module.moderationSettings, "getOrCreate").mockResolvedValue(settings);
+    });
+
+    describe("execute", () => {
+        it("should unmute the member", async () => {
+            const editSpy = vi.spyOn(command.client.api.guilds, "editMember");
+
+            await command.execute(interaction, options);
+
+            expect(editSpy).toHaveBeenCalledOnce();
+            expect(editSpy).toHaveBeenCalledWith(mockGuild.id, options.member.user.id, {
+                communication_disabled_until: null
+            });
+        });
+
+        it("should send a success message", async () => {
+            const createSpy = vi.spyOn(interaction, "createMessage");
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith({
+                content: expect.stringContaining(`Case \`34\` | Successfully unmuted \`${options.member.user.username}\`.`),
+                flags: MessageFlags.Ephemeral
+            });
+        });
+
+        it("should notify the user", async () => {
+            await command.execute(interaction, options);
+
+            expect(command.module.notifyUser).toHaveBeenCalledOnce();
+            expect(command.module.notifyUser).toHaveBeenCalledWith({
+                guild: mockGuild,
+                reason: options.reason,
+                type: CaseType.Unmute,
+                userID: options.member.user.id
+            });
+        });
+
+        it("should create a log message", async () => {
+            await command.execute(interaction, options);
+
+            expect(command.module.createLogMessage).toHaveBeenCalledOnce();
+            expect(command.module.createLogMessage).toHaveBeenCalledWith({
+                case: mockCase,
+                creator: interaction.user,
+                reason: options.reason,
+                user: options.member.user
+            }, settings);
+        });
+
+        it("should ignore if the interaction was sent outside a guild", async () => {
+            delete interaction.guildID;
+
+            await command.execute(interaction, options);
+
+            expect(interaction.acknowledged).toBe(false);
+        });
+
+        it("should show an error message if the user is not muted", async () => {
+            const createSpy = vi.spyOn(interaction, "createMessage");
+            options.member.communication_disabled_until = null;
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith({
+                content: expect.stringContaining("That member is not muted"),
+                flags: MessageFlags.Ephemeral
+            });
+        });
+    });
+});

--- a/apps/barry/tests/modules/moderation/commands/chatinput/unmute/index.test.ts
+++ b/apps/barry/tests/modules/moderation/commands/chatinput/unmute/index.test.ts
@@ -135,5 +135,21 @@ describe("/unmute", () => {
                 flags: MessageFlags.Ephemeral
             });
         });
+
+        it("should show an error message if the unmute failed", async () => {
+            const error = new Error("Oh no!");
+            const createSpy = vi.spyOn(interaction, "createMessage");
+            vi.spyOn(command.client.api.guilds, "editMember").mockRejectedValue(error);
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith({
+                content: expect.stringContaining("Failed to unmute this member"),
+                flags: MessageFlags.Ephemeral
+            });
+            expect(command.client.logger.error).toHaveBeenCalledOnce();
+            expect(command.client.logger.error).toHaveBeenCalledWith(error);
+        });
     });
 });


### PR DESCRIPTION
Closes #20, part of #24.
- Adds a `/unmute` command.
- Quick bug fix for `/mute` where it notify the user, even though the unmute failed.