### PR TITLE
feat: implement delete case command

### DIFF
--- a/apps/barry/src/modules/moderation/commands/chatinput/cases/content.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/cases/content.ts
@@ -1,0 +1,61 @@
+import type {
+    APIEmbedField,
+    APIInteractionResponseCallbackData,
+    APIUser
+} from "@discordjs/core";
+import type { Case, CaseNote } from "@prisma/client";
+
+import { CASE_EMOJIS, CASE_TITLES } from "../../../constants.js";
+import { getAvatarURL } from "@barry/core";
+import config from "../../../../../config.js";
+
+/**
+ * Get the content for a case.
+ *
+ * @param entity The case to get the content for.
+ * @param notes The notes for the case.
+ * @param creator The creator of the case.
+ * @param user The user that the case is for.
+ * @returns The content for the case.
+ */
+export function getCaseContent(
+    entity: Case,
+    notes: CaseNote[],
+    creator: APIUser,
+    user: APIUser
+): APIInteractionResponseCallbackData {
+    const title = CASE_TITLES[entity.type];
+    const emoji = CASE_EMOJIS[entity.type];
+
+    const fields: APIEmbedField[] = [];
+    if (notes.length > 0) {
+        fields.push({
+            name: "**Notes**",
+            value: notes
+                .map((n) => `\`${n.id}\` <@${n.creatorID}> — <t:${Math.trunc(n.createdAt.getTime() / 1000)}:R>\n${n.content}`)
+                .join("\n\n")
+        });
+    }
+
+    return {
+        embeds: [{
+            author: {
+                icon_url: getAvatarURL(user, { size: 128 }),
+                name: user.username
+            },
+            color: config.defaultColor,
+            description: `**Target:** <@${entity.userID}> \`${user.username}\``
+                + `\n**Creator:** <@${entity.creatorID}> \`${creator.username}\``
+                + `\n**Date:** <t:${Math.trunc(entity.createdAt.getTime() / 1000)}:R>`,
+            fields: fields,
+            footer: {
+                text: `User ID: ${entity.userID}`
+            },
+            thumbnail: {
+                url: getAvatarURL(user, { size: 256 })
+            },
+            timestamp: entity.createdAt.toISOString(),
+            title: `${emoji} ${title} | Inspecting case #${entity.id}`
+        }]
+    };
+}

--- a/apps/barry/src/modules/moderation/commands/chatinput/cases/delete/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/cases/delete/index.ts
@@ -1,0 +1,132 @@
+import {
+    type ApplicationCommandInteraction,
+    SlashCommand,
+    SlashCommandOptionBuilder
+} from "@barry/core";
+import type ModerationModule from "../../../../index.js";
+
+import {
+    ButtonStyle,
+    ComponentType,
+    MessageFlags,
+    PermissionFlagsBits
+} from "@discordjs/core";
+import { getCaseContent } from "../content.js";
+import config from "../../../../../../config.js";
+
+/**
+ * Options for the "/cases delete" command.
+ */
+export interface DeleteCasesOptions {
+    /**
+     * The ID of the case to delete.
+     */
+    case: number;
+}
+
+/**
+ * Represents a slash command to delete a specific case.
+ */
+export default class extends SlashCommand<ModerationModule> {
+    /**
+     * Represents a slash command to delete a specific case.
+     *
+     * @param module The module that this command belongs to.
+     */
+    constructor(module: ModerationModule) {
+        super(module, {
+            name: "delete",
+            description: "Delete a specific case.",
+            defaultMemberPermissions: PermissionFlagsBits.ManageGuild,
+            guildOnly: true,
+            options: {
+                case: SlashCommandOptionBuilder.integer({
+                    description: "The ID of the case to delete.",
+                    minimum: 1,
+                    required: true
+                })
+            }
+        });
+    }
+
+    /**
+     * Delete a specific case.
+     *
+     * @param interaction The interaction that triggered the command.
+     * @param options The options for the command.
+     */
+    async execute(interaction: ApplicationCommandInteraction, options: DeleteCasesOptions): Promise<void> {
+        if (!interaction.isInvokedInGuild()) {
+            return;
+        }
+
+        const entity = await this.module.cases.get(interaction.guildID, options.case, true);
+        if (entity === null) {
+            return interaction.createMessage({
+                content: `${config.emotes.error} That case does not exist.`,
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
+        const creator = await this.client.api.users.get(entity.creatorID);
+        const user = await this.client.api.users.get(entity.userID);
+
+        await interaction.createMessage({
+            ...getCaseContent(entity, entity.notes.slice(0, 4), creator, user),
+            components: [{
+                components: [
+                    {
+                        custom_id: "confirm",
+                        label: "Confirm",
+                        style: ButtonStyle.Danger,
+                        type: ComponentType.Button
+                    },
+                    {
+                        custom_id: "cancel",
+                        label: "Cancel",
+                        style: ButtonStyle.Secondary,
+                        type: ComponentType.Button
+                    }
+                ],
+                type: ComponentType.ActionRow
+            }],
+            content: `### ${config.emotes.error} Are you sure you want to delete this case?`,
+            flags: MessageFlags.Ephemeral
+        });
+
+        const response = await interaction.awaitMessageComponent({
+            customIDs: ["confirm", "cancel"]
+        });
+
+        if (response === undefined) {
+            await interaction.editOriginalMessage({
+                components: [],
+                content: `${config.emotes.error} It took you too long to respond. Please try again.`,
+                embeds: [],
+                flags: MessageFlags.Ephemeral
+            });
+
+            return;
+        }
+
+        if (response.data.customID === "cancel") {
+            return response.editParent({
+                components: [],
+                content: `${config.emotes.check} Cancelled the deletion of case \`${options.case}\`.`,
+                embeds: [],
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
+        if (response.data.customID === "confirm") {
+            await this.module.cases.delete(interaction.guildID, options.case);
+
+            return response.editParent({
+                components: [],
+                content: `${config.emotes.check} Successfully deleted case \`${options.case}\`.`,
+                embeds: [],
+                flags: MessageFlags.Ephemeral
+            });
+        }
+    }
+}

--- a/apps/barry/src/modules/moderation/commands/chatinput/cases/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/cases/index.ts
@@ -1,6 +1,7 @@
 import type ModerationModule from "../../../index.js";
 
 import { SlashCommand } from "@barry/core";
+import DeleteCommand from "./delete/index.js";
 import ViewCommand from "./view/index.js";
 
 /**
@@ -17,7 +18,7 @@ export default class extends SlashCommand<ModerationModule> {
             name: "cases",
             description: "Manage or view a case.",
             guildOnly: true,
-            children: [ViewCommand]
+            children: [DeleteCommand, ViewCommand]
         });
     }
 

--- a/apps/barry/tests/modules/moderation/commands/chatinput/cases/delete/index.test.ts
+++ b/apps/barry/tests/modules/moderation/commands/chatinput/cases/delete/index.test.ts
@@ -1,0 +1,185 @@
+import type { CaseWithNotes } from "../../../../../../../src/modules/moderation/database.js";
+
+import {
+    ApplicationCommandInteraction,
+    MessageComponentInteraction
+} from "@barry/core";
+import {
+    ButtonStyle,
+    ComponentType,
+    MessageFlags
+} from "@discordjs/core";
+import {
+    createMockApplicationCommandInteraction,
+    createMockMessageComponentInteraction,
+    mockGuild,
+    mockUser
+} from "@barry/testing";
+
+import { CaseType } from "@prisma/client";
+import { createMockApplication } from "../../../../../../mocks/application.js";
+
+import DeleteCommand, { type DeleteCasesOptions } from "../../../../../../../src/modules/moderation/commands/chatinput/cases/delete/index.js";
+import ModerationModule from "../../../../../../../src/modules/moderation/index.js";
+
+describe("/cases delete", () => {
+    let command: DeleteCommand;
+    let interaction: ApplicationCommandInteraction;
+    let mockCase: CaseWithNotes;
+    let options: DeleteCasesOptions;
+
+    beforeEach(() => {
+        const client = createMockApplication();
+        const module = new ModerationModule(client);
+        command = new DeleteCommand(module);
+
+        const data = createMockApplicationCommandInteraction();
+        interaction = new ApplicationCommandInteraction(data, client, vi.fn());
+        interaction.editOriginalMessage = vi.fn();
+
+        mockCase = {
+            createdAt: new Date("01-01-2023"),
+            creatorID: mockUser.id,
+            guildID: mockGuild.id,
+            id: 34,
+            notes: [{
+                caseID: 34,
+                content: "Rude!",
+                createdAt: new Date("01-01-2023"),
+                creatorID: mockUser.id,
+                guildID: mockGuild.id,
+                id: 1
+            }],
+            type: CaseType.Note,
+            userID: "257522665437265920"
+        };
+        options = {
+            case: 34
+        };
+
+        vi.spyOn(module.cases, "get").mockResolvedValue(mockCase);
+
+        vi.spyOn(client.api.users, "get")
+            .mockResolvedValueOnce(mockUser)
+            .mockResolvedValue({ ...mockUser, id: "257522665437265920" });
+    });
+
+    describe("execute", () => {
+        it("should ignore if the interaction is not invoked in a guild", async () => {
+            delete interaction.guildID;
+
+            await command.execute(interaction, options);
+
+            expect(interaction.acknowledged).toBe(false);
+        });
+
+        it("should show an error message if the provided case does not exist", async () => {
+            vi.spyOn(command.module.cases, "get").mockResolvedValue(null);
+            const createSpy = vi.spyOn(interaction, "createMessage");
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith({
+                content: expect.stringContaining("That case does not exist."),
+                flags: MessageFlags.Ephemeral
+            });
+        });
+
+        it("should prompt the user to confirm the deletion", async () => {
+            vi.spyOn(interaction, "awaitMessageComponent").mockResolvedValue(undefined);
+            const createSpy = vi.spyOn(interaction, "createMessage");
+
+            await command.execute(interaction, options);
+
+            expect(createSpy).toHaveBeenCalledOnce();
+            expect(createSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    components: [{
+                        components: [
+                            {
+                                custom_id: "confirm",
+                                label: "Confirm",
+                                style: ButtonStyle.Danger,
+                                type: ComponentType.Button
+                            },
+                            {
+                                custom_id: "cancel",
+                                label: "Cancel",
+                                style: ButtonStyle.Secondary,
+                                type: ComponentType.Button
+                            }
+                        ],
+                        type: ComponentType.ActionRow
+                    }],
+                    content: expect.stringContaining("Are you sure you want to delete this case?"),
+                    flags: MessageFlags.Ephemeral
+                })
+            );
+        });
+
+        it("should delete the case if the user confirms", async () => {
+            const data = createMockMessageComponentInteraction({
+                custom_id: "confirm",
+                component_type: ComponentType.Button
+            });
+            const response = new MessageComponentInteraction(data, command.client, vi.fn());
+
+            vi.spyOn(interaction, "awaitMessageComponent").mockResolvedValue(response);
+            const deleteSpy = vi.spyOn(command.module.cases, "delete").mockResolvedValue(mockCase);
+            const editSpy = vi.spyOn(response, "editParent");
+
+            await command.execute(interaction, options);
+
+            expect(deleteSpy).toHaveBeenCalledOnce();
+            expect(deleteSpy).toHaveBeenCalledWith(interaction.guildID, options.case);
+            expect(editSpy).toHaveBeenCalledOnce();
+            expect(editSpy).toHaveBeenCalledWith({
+                components: [],
+                content: expect.stringContaining("Successfully deleted case `34`."),
+                embeds: [],
+                flags: MessageFlags.Ephemeral
+            });
+        });
+
+        it("should do nothing if the user cancels", async () => {
+            const data = createMockMessageComponentInteraction({
+                custom_id: "cancel",
+                component_type: ComponentType.Button
+            });
+            const response = new MessageComponentInteraction(data, command.client, vi.fn());
+
+            vi.spyOn(interaction, "awaitMessageComponent").mockResolvedValue(response);
+            const deleteSpy = vi.spyOn(command.module.cases, "delete").mockResolvedValue(mockCase);
+            const editSpy = vi.spyOn(response, "editParent");
+
+            await command.execute(interaction, options);
+
+            expect(deleteSpy).not.toHaveBeenCalled();
+            expect(editSpy).toHaveBeenCalledOnce();
+            expect(editSpy).toHaveBeenCalledWith({
+                components: [],
+                content: expect.stringContaining("Cancelled the deletion of case `34`."),
+                embeds: [],
+                flags: MessageFlags.Ephemeral
+            });
+        });
+
+        it("should show a timeout message if the user does not respond", async () => {
+            vi.spyOn(interaction, "awaitMessageComponent").mockResolvedValue(undefined);
+            const deleteSpy = vi.spyOn(command.module.cases, "delete").mockResolvedValue(mockCase);
+            const editSpy = vi.spyOn(interaction, "editOriginalMessage");
+
+            await command.execute(interaction, options);
+
+            expect(deleteSpy).not.toHaveBeenCalled();
+            expect(editSpy).toHaveBeenCalledOnce();
+            expect(editSpy).toHaveBeenCalledWith({
+                components: [],
+                content: expect.stringContaining("It took you too long to respond. Please try again."),
+                embeds: [],
+                flags: MessageFlags.Ephemeral
+            });
+        });
+    });
+});


### PR DESCRIPTION
Part of #23.
- Adds a `/cases delete` command.
- Has confirmation for deleting cases.
- Splits up the content for individual cases to a separate function.