### PR TITLE
chore: remove duplicate cases

### DIFF
--- a/apps/barry/tests/modules/moderation/commands/chatinput/ban/index.test.ts
+++ b/apps/barry/tests/modules/moderation/commands/chatinput/ban/index.test.ts
@@ -19,6 +19,7 @@ import {
 
 import { COMMON_SEVERE_REASONS } from "../../../../../../src/modules/moderation/constants.js";
 import { createMockApplication } from "../../../../../mocks/application.js";
+import { mockCase } from "../../../mocks/case.js";
 
 import BanCommand, { type BanOptions } from "../../../../../../src/modules/moderation/commands/chatinput/ban/index.js";
 import ModerationModule from "../../../../../../src/modules/moderation/index.js";
@@ -27,7 +28,7 @@ import * as permissions from "../../../../../../src/modules/moderation/functions
 describe("/ban", () => {
     let command: BanCommand;
     let interaction: ApplicationCommandInteraction;
-    let mockCase: Case;
+    let entity: Case;
     let options: BanOptions;
     let settings: ModerationSettings;
 
@@ -43,14 +44,7 @@ describe("/ban", () => {
             interaction.data.resolved.members.set("257522665437265920", mockInteractionMember);
         }
 
-        mockCase = {
-            createdAt: new Date("1-1-2023"),
-            creatorID: mockUser.id,
-            guildID: mockGuild.id,
-            id: 34,
-            type: CaseType.Ban,
-            userID: "257522665437265920"
-        };
+        entity = { ...mockCase, type: CaseType.Ban };
         options = {
             user: {
                 ...mockUser,
@@ -73,7 +67,7 @@ describe("/ban", () => {
         vi.spyOn(client.api.guilds, "getMember").mockResolvedValue(mockMember);
         vi.spyOn(client.api.guilds, "banUser").mockResolvedValue(undefined);
         vi.spyOn(client.api.users, "createDM").mockResolvedValue({ ...mockChannel, position: 0 });
-        vi.spyOn(module.cases, "create").mockResolvedValue(mockCase);
+        vi.spyOn(module.cases, "create").mockResolvedValue(entity);
         vi.spyOn(module.moderationSettings, "getOrCreate").mockResolvedValue(settings);
     });
 
@@ -351,7 +345,7 @@ describe("/ban", () => {
 
             expect(createSpy).toHaveBeenCalledOnce();
             expect(createSpy).toHaveBeenCalledWith({
-                case: mockCase,
+                case: entity,
                 creator: interaction.user,
                 reason: options.reason,
                 user: options.user

--- a/apps/barry/tests/modules/moderation/commands/chatinput/cases/delete/index.test.ts
+++ b/apps/barry/tests/modules/moderation/commands/chatinput/cases/delete/index.test.ts
@@ -12,11 +12,10 @@ import {
 import {
     createMockApplicationCommandInteraction,
     createMockMessageComponentInteraction,
-    mockGuild,
     mockUser
 } from "@barry/testing";
 
-import { CaseType } from "@prisma/client";
+import { mockCase, mockCaseNote } from "../../../../mocks/case.js";
 import { createMockApplication } from "../../../../../../mocks/application.js";
 
 import DeleteCommand, { type DeleteCasesOptions } from "../../../../../../../src/modules/moderation/commands/chatinput/cases/delete/index.js";
@@ -25,7 +24,7 @@ import ModerationModule from "../../../../../../../src/modules/moderation/index.
 describe("/cases delete", () => {
     let command: DeleteCommand;
     let interaction: ApplicationCommandInteraction;
-    let mockCase: CaseWithNotes;
+    let entity: CaseWithNotes;
     let options: DeleteCasesOptions;
 
     beforeEach(() => {
@@ -37,27 +36,12 @@ describe("/cases delete", () => {
         interaction = new ApplicationCommandInteraction(data, client, vi.fn());
         interaction.editOriginalMessage = vi.fn();
 
-        mockCase = {
-            createdAt: new Date("01-01-2023"),
-            creatorID: mockUser.id,
-            guildID: mockGuild.id,
-            id: 34,
-            notes: [{
-                caseID: 34,
-                content: "Rude!",
-                createdAt: new Date("01-01-2023"),
-                creatorID: mockUser.id,
-                guildID: mockGuild.id,
-                id: 1
-            }],
-            type: CaseType.Note,
-            userID: "257522665437265920"
-        };
+        entity = { ...mockCase, notes: [mockCaseNote] };
         options = {
             case: 34
         };
 
-        vi.spyOn(module.cases, "get").mockResolvedValue(mockCase);
+        vi.spyOn(module.cases, "get").mockResolvedValue(entity);
 
         vi.spyOn(client.api.users, "get")
             .mockResolvedValueOnce(mockUser)
@@ -126,7 +110,7 @@ describe("/cases delete", () => {
             const response = new MessageComponentInteraction(data, command.client, vi.fn());
 
             vi.spyOn(interaction, "awaitMessageComponent").mockResolvedValue(response);
-            const deleteSpy = vi.spyOn(command.module.cases, "delete").mockResolvedValue(mockCase);
+            const deleteSpy = vi.spyOn(command.module.cases, "delete").mockResolvedValue(entity);
             const editSpy = vi.spyOn(response, "editParent");
 
             await command.execute(interaction, options);
@@ -150,7 +134,7 @@ describe("/cases delete", () => {
             const response = new MessageComponentInteraction(data, command.client, vi.fn());
 
             vi.spyOn(interaction, "awaitMessageComponent").mockResolvedValue(response);
-            const deleteSpy = vi.spyOn(command.module.cases, "delete").mockResolvedValue(mockCase);
+            const deleteSpy = vi.spyOn(command.module.cases, "delete").mockResolvedValue(entity);
             const editSpy = vi.spyOn(response, "editParent");
 
             await command.execute(interaction, options);
@@ -167,7 +151,7 @@ describe("/cases delete", () => {
 
         it("should show a timeout message if the user does not respond", async () => {
             vi.spyOn(interaction, "awaitMessageComponent").mockResolvedValue(undefined);
-            const deleteSpy = vi.spyOn(command.module.cases, "delete").mockResolvedValue(mockCase);
+            const deleteSpy = vi.spyOn(command.module.cases, "delete").mockResolvedValue(entity);
             const editSpy = vi.spyOn(interaction, "editOriginalMessage");
 
             await command.execute(interaction, options);

--- a/apps/barry/tests/modules/moderation/commands/chatinput/cases/view/index.test.ts
+++ b/apps/barry/tests/modules/moderation/commands/chatinput/cases/view/index.test.ts
@@ -1,10 +1,11 @@
-import type { CaseWithNotes } from "../../../../../../../src/modules/moderation/database.js";
-
+import type { CaseWithNotes } from "../../../../../../../dist/modules/moderation/database.js";
 import {
     createMockApplicationCommandInteraction,
     mockGuild,
     mockUser
 } from "@barry/testing";
+import { mockCase, mockCaseNote } from "../../../../mocks/case.js";
+
 import { ApplicationCommandInteraction } from "@barry/core";
 import { CaseType } from "@prisma/client";
 import { MessageFlags } from "@discordjs/core";
@@ -47,18 +48,7 @@ describe("/cases view", () => {
             };
 
             vi.spyOn(command.module.cases, "get").mockResolvedValue({
-                createdAt: new Date("01-01-2023"),
-                creatorID: mockUser.id,
-                guildID: mockGuild.id,
-                id: 34,
-                notes: [{
-                    content: "Rude!",
-                    createdAt: new Date("01-01-2023"),
-                    creatorID: mockUser.id,
-                    id: 1
-                }],
-                type: CaseType.Note,
-                userID: userID
+                ...mockCase, notes: [mockCaseNote]
             } as CaseWithNotes);
             vi.spyOn(command.client.api.users, "get")
                 .mockResolvedValueOnce(mockUser)
@@ -117,22 +107,8 @@ describe("/cases view", () => {
         beforeEach(() => {
             vi.spyOn(command.client.api.guilds, "get").mockResolvedValue(mockGuild);
             vi.spyOn(command.module.cases, "getAll").mockResolvedValue([
-                {
-                    createdAt: new Date("01-02-2023"),
-                    creatorID: mockUser.id,
-                    guildID: mockGuild.id,
-                    id: 35,
-                    type: CaseType.Note,
-                    userID: "257522665437265920"
-                },
-                {
-                    createdAt: new Date("01-01-2023"),
-                    creatorID: mockUser.id,
-                    guildID: mockGuild.id,
-                    id: 34,
-                    type: CaseType.Note,
-                    userID: "257522665437265920"
-                }
+                { ...mockCase, id: 35 },
+                { ...mockCase, id: 33 }
             ]);
         });
 
@@ -204,22 +180,8 @@ describe("/cases view", () => {
 
             vi.spyOn(command.client.api.guilds, "get").mockResolvedValue(mockGuild);
             vi.spyOn(command.module.cases, "getByUser").mockResolvedValue([
-                {
-                    createdAt: new Date("01-02-2023"),
-                    creatorID: mockUser.id,
-                    guildID: mockGuild.id,
-                    id: 35,
-                    type: CaseType.Note,
-                    userID: "257522665437265920"
-                },
-                {
-                    createdAt: new Date("01-01-2023"),
-                    creatorID: mockUser.id,
-                    guildID: mockGuild.id,
-                    id: 34,
-                    type: CaseType.Note,
-                    userID: "257522665437265920"
-                }
+                { ...mockCase, id: 35 },
+                { ...mockCase, id: 33 }
             ]);
         });
 

--- a/apps/barry/tests/modules/moderation/commands/chatinput/kick/index.test.ts
+++ b/apps/barry/tests/modules/moderation/commands/chatinput/kick/index.test.ts
@@ -13,6 +13,7 @@ import {
 
 import { COMMON_SEVERE_REASONS } from "../../../../../../src/modules/moderation/constants.js";
 import { createMockApplication } from "../../../../../mocks/application.js";
+import { mockCase } from "../../../mocks/case.js";
 
 import KickCommand, { type KickOptions } from "../../../../../../src/modules/moderation/commands/chatinput/kick/index.js";
 import ModerationModule from "../../../../../../src/modules/moderation/index.js";
@@ -21,7 +22,7 @@ import * as permissions from "../../../../../../src/modules/moderation/functions
 describe("/kick", () => {
     let command: KickCommand;
     let interaction: ApplicationCommandInteraction;
-    let mockCase: Case;
+    let entity: Case;
     let options: KickOptions;
     let settings: ModerationSettings;
 
@@ -34,14 +35,7 @@ describe("/kick", () => {
         const data = createMockApplicationCommandInteraction();
         interaction = new ApplicationCommandInteraction(data, client, vi.fn());
 
-        mockCase = {
-            createdAt: new Date("1-1-2023"),
-            creatorID: mockUser.id,
-            guildID: mockGuild.id,
-            id: 34,
-            type: CaseType.Kick,
-            userID: "257522665437265920"
-        };
+        entity = { ...mockCase, type: CaseType.Kick };
         options = {
             member: {
                 ...mockMember,
@@ -66,7 +60,7 @@ describe("/kick", () => {
         vi.spyOn(client.api.guilds, "getMember").mockResolvedValue(mockMember);
         vi.spyOn(client.api.guilds, "removeMember").mockResolvedValue(undefined);
         vi.spyOn(client.api.users, "createDM").mockResolvedValue({ ...mockChannel, position: 0 });
-        vi.spyOn(module.cases, "create").mockResolvedValue(mockCase);
+        vi.spyOn(module.cases, "create").mockResolvedValue(entity);
         vi.spyOn(module.moderationSettings, "getOrCreate").mockResolvedValue(settings);
     });
 
@@ -207,7 +201,7 @@ describe("/kick", () => {
 
             expect(createSpy).toHaveBeenCalledOnce();
             expect(createSpy).toHaveBeenCalledWith({
-                case: mockCase,
+                case: entity,
                 creator: interaction.user,
                 reason: options.reason,
                 user: options.member.user

--- a/apps/barry/tests/modules/moderation/commands/chatinput/mute/index.test.ts
+++ b/apps/barry/tests/modules/moderation/commands/chatinput/mute/index.test.ts
@@ -13,6 +13,7 @@ import {
 
 import { COMMON_MINOR_REASONS } from "../../../../../../src/modules/moderation/constants.js";
 import { createMockApplication } from "../../../../../mocks/application.js";
+import { mockCase } from "../../../mocks/case.js";
 
 import MuteCommand, { type MuteOptions } from "../../../../../../src/modules/moderation/commands/chatinput/mute/index.js";
 import ModerationModule from "../../../../../../src/modules/moderation/index.js";
@@ -22,7 +23,7 @@ import * as permissions from "../../../../../../src/modules/moderation/functions
 describe("/mute", () => {
     let command: MuteCommand;
     let interaction: ApplicationCommandInteraction;
-    let mockCase: Case;
+    let entity: Case;
     let options: MuteOptions;
     let settings: ModerationSettings;
 
@@ -36,14 +37,7 @@ describe("/mute", () => {
         const data = createMockApplicationCommandInteraction();
         interaction = new ApplicationCommandInteraction(data, client, vi.fn());
 
-        mockCase = {
-            createdAt: new Date(),
-            creatorID: mockUser.id,
-            guildID: mockGuild.id,
-            id: 34,
-            type: CaseType.Mute,
-            userID: "257522665437265920"
-        };
+        entity = { ...mockCase, type: CaseType.Mute };
         options = {
             duration: "5m",
             member: {
@@ -69,7 +63,7 @@ describe("/mute", () => {
         vi.spyOn(client.api.guilds, "getMember").mockResolvedValue(mockMember);
         vi.spyOn(client.api.guilds, "editMember").mockResolvedValue(mockMember);
         vi.spyOn(client.api.users, "createDM").mockResolvedValue({ ...mockChannel, position: 0 });
-        vi.spyOn(module.cases, "create").mockResolvedValue(mockCase);
+        vi.spyOn(module.cases, "create").mockResolvedValue(entity);
         vi.spyOn(module.moderationSettings, "getOrCreate").mockResolvedValue(settings);
     });
 
@@ -143,7 +137,7 @@ describe("/mute", () => {
 
             expect(createSpy).toHaveBeenCalledOnce();
             expect(createSpy).toHaveBeenCalledWith({
-                case: mockCase,
+                case: entity,
                 creator: interaction.user,
                 duration: 300,
                 reason: options.reason,

--- a/apps/barry/tests/modules/moderation/commands/chatinput/note/index.test.ts
+++ b/apps/barry/tests/modules/moderation/commands/chatinput/note/index.test.ts
@@ -5,12 +5,12 @@ import {
 } from "@prisma/client";
 import {
     createMockApplicationCommandInteraction,
-    mockGuild,
     mockUser
 } from "@barry/testing";
 import { ApplicationCommandInteraction } from "@barry/core";
 import { MessageFlags } from "@discordjs/core";
 import { createMockApplication } from "../../../../../mocks/application.js";
+import { mockCase } from "../../../mocks/case.js";
 
 import NoteCommand, { type NoteOptions } from "../../../../../../src/modules/moderation/commands/chatinput/note/index.js";
 import ModerationModule from "../../../../../../src/modules/moderation/index.js";
@@ -18,7 +18,7 @@ import ModerationModule from "../../../../../../src/modules/moderation/index.js"
 describe("/note", () => {
     let command: NoteCommand;
     let interaction: ApplicationCommandInteraction;
-    let mockCase: Case;
+    let entity: Case;
     let options: NoteOptions;
     let settings: ModerationSettings;
 
@@ -30,14 +30,7 @@ describe("/note", () => {
         const data = createMockApplicationCommandInteraction();
         interaction = new ApplicationCommandInteraction(data, client, vi.fn());
 
-        mockCase = {
-            createdAt: new Date("1-1-2023"),
-            creatorID: mockUser.id,
-            guildID: mockGuild.id,
-            id: 34,
-            type: CaseType.Note,
-            userID: "257522665437265920"
-        };
+        entity = { ...mockCase, type: CaseType.Note };
         options = {
             note: "This is a note.",
             user: {
@@ -54,7 +47,7 @@ describe("/note", () => {
         };
 
         module.createLogMessage = vi.fn();
-        vi.spyOn(module.cases, "create").mockResolvedValue(mockCase);
+        vi.spyOn(module.cases, "create").mockResolvedValue(entity);
         vi.spyOn(module.moderationSettings, "getOrCreate").mockResolvedValue(settings);
     });
 
@@ -77,7 +70,7 @@ describe("/note", () => {
 
             expect(command.module.createLogMessage).toHaveBeenCalledOnce();
             expect(command.module.createLogMessage).toHaveBeenCalledWith({
-                case: mockCase,
+                case: entity,
                 creator: interaction.user,
                 reason: options.note,
                 user: options.user

--- a/apps/barry/tests/modules/moderation/commands/chatinput/unban/index.test.ts
+++ b/apps/barry/tests/modules/moderation/commands/chatinput/unban/index.test.ts
@@ -13,6 +13,7 @@ import { ApplicationCommandInteraction } from "@barry/core";
 import { DiscordAPIError } from "@discordjs/rest";
 import { MessageFlags } from "@discordjs/core";
 import { createMockApplication } from "../../../../../mocks/index.js";
+import { mockCase } from "../../../mocks/case.js";
 
 import UnbanCommand, { type UnbanOptions } from "../../../../../../src/modules/moderation/commands/chatinput/unban/index.js";
 import ModerationModule from "../../../../../../src/modules/moderation/index.js";
@@ -20,7 +21,7 @@ import ModerationModule from "../../../../../../src/modules/moderation/index.js"
 describe("/unban", () => {
     let command: UnbanCommand;
     let interaction: ApplicationCommandInteraction;
-    let mockCase: Case;
+    let entity: Case;
     let options: UnbanOptions;
     let settings: ModerationSettings;
 
@@ -32,14 +33,7 @@ describe("/unban", () => {
         const data = createMockApplicationCommandInteraction();
         interaction = new ApplicationCommandInteraction(data, client, vi.fn());
 
-        mockCase = {
-            createdAt: new Date("1-1-2023"),
-            creatorID: mockUser.id,
-            guildID: mockGuild.id,
-            id: 34,
-            type: CaseType.Unban,
-            userID: "257522665437265920"
-        };
+        entity = { ...mockCase, type: CaseType.Unban };
         options = {
             reason: "Oops",
             user: {
@@ -59,7 +53,7 @@ describe("/unban", () => {
         module.notifyUser = vi.fn();
         vi.spyOn(client.api.guilds, "unbanUser").mockResolvedValue();
         vi.spyOn(client.api.guilds, "get").mockResolvedValue(mockGuild);
-        vi.spyOn(module.cases, "create").mockResolvedValue(mockCase);
+        vi.spyOn(module.cases, "create").mockResolvedValue(entity);
         vi.spyOn(module.moderationSettings, "getOrCreate").mockResolvedValue(settings);
     });
 
@@ -92,7 +86,7 @@ describe("/unban", () => {
 
             expect(command.module.createLogMessage).toHaveBeenCalledOnce();
             expect(command.module.createLogMessage).toHaveBeenCalledWith({
-                case: mockCase,
+                case: entity,
                 creator: interaction.user,
                 reason: options.reason,
                 user: options.user

--- a/apps/barry/tests/modules/moderation/commands/chatinput/unmute/index.test.ts
+++ b/apps/barry/tests/modules/moderation/commands/chatinput/unmute/index.test.ts
@@ -13,6 +13,7 @@ import {
 import { ApplicationCommandInteraction } from "@barry/core";
 import { MessageFlags } from "@discordjs/core";
 import { createMockApplication } from "../../../../../mocks/index.js";
+import { mockCase } from "../../../mocks/case.js";
 
 import UnmuteCommand, { type UnmuteOptions } from "../../../../../../src/modules/moderation/commands/chatinput/unmute/index.js";
 import ModerationModule from "../../../../../../src/modules/moderation/index.js";
@@ -20,7 +21,7 @@ import ModerationModule from "../../../../../../src/modules/moderation/index.js"
 describe("/unmute", () => {
     let command: UnmuteCommand;
     let interaction: ApplicationCommandInteraction;
-    let mockCase: Case;
+    let entity: Case;
     let options: UnmuteOptions;
     let settings: ModerationSettings;
 
@@ -32,14 +33,7 @@ describe("/unmute", () => {
         const data = createMockApplicationCommandInteraction();
         interaction = new ApplicationCommandInteraction(data, client, vi.fn());
 
-        mockCase = {
-            createdAt: new Date("1-1-2023"),
-            creatorID: mockUser.id,
-            guildID: mockGuild.id,
-            id: 34,
-            type: CaseType.Unmute,
-            userID: "257522665437265920"
-        };
+        entity = { ...mockCase, type: CaseType.Unmute };
         options = {
             member: {
                 ...mockMember,
@@ -63,7 +57,7 @@ describe("/unmute", () => {
         module.notifyUser = vi.fn();
         vi.spyOn(client.api.guilds, "editMember").mockResolvedValue(mockMember);
         vi.spyOn(client.api.guilds, "get").mockResolvedValue(mockGuild);
-        vi.spyOn(module.cases, "create").mockResolvedValue(mockCase);
+        vi.spyOn(module.cases, "create").mockResolvedValue(entity);
         vi.spyOn(module.moderationSettings, "getOrCreate").mockResolvedValue(settings);
     });
 
@@ -108,7 +102,7 @@ describe("/unmute", () => {
 
             expect(command.module.createLogMessage).toHaveBeenCalledOnce();
             expect(command.module.createLogMessage).toHaveBeenCalledWith({
-                case: mockCase,
+                case: entity,
                 creator: interaction.user,
                 reason: options.reason,
                 user: options.member.user

--- a/apps/barry/tests/modules/moderation/commands/chatinput/warn/index.test.ts
+++ b/apps/barry/tests/modules/moderation/commands/chatinput/warn/index.test.ts
@@ -14,17 +14,17 @@ import {
 import { COMMON_MINOR_REASONS } from "../../../../../../src/modules/moderation/constants.js";
 import { DiscordAPIError } from "@discordjs/rest";
 import { createMockApplication } from "../../../../../mocks/application.js";
+import { mockCase } from "../../../mocks/case.js";
 import { mockGuild } from "@barry/testing";
 
 import WarnCommand, { type WarnOptions } from "../../../../../../src/modules/moderation/commands/chatinput/warn/index.js";
 import ModerationModule from "../../../../../../src/modules/moderation/index.js";
-
 import * as permissions from "../../../../../../src/modules/moderation/functions/permissions.js";
 
 describe("/warn", () => {
     let command: WarnCommand;
     let interaction: ApplicationCommandInteraction;
-    let mockCase: Case;
+    let entity: Case;
     let options: WarnOptions;
     let settings: ModerationSettings;
 
@@ -37,14 +37,7 @@ describe("/warn", () => {
         const data = createMockApplicationCommandInteraction();
         interaction = new ApplicationCommandInteraction(data, client, vi.fn());
 
-        mockCase = {
-            createdAt: new Date("1-1-2023"),
-            creatorID: mockUser.id,
-            guildID: mockGuild.id,
-            id: 34,
-            type: CaseType.Warn,
-            userID: "257522665437265920"
-        };
+        entity = { ...mockCase, type: CaseType.Warn };
         options = {
             member: {
                 ...mockMember,
@@ -67,7 +60,7 @@ describe("/warn", () => {
         vi.spyOn(client.api.guilds, "get").mockResolvedValue(mockGuild);
         vi.spyOn(client.api.guilds, "getMember").mockResolvedValue(mockMember);
         vi.spyOn(client.api.users, "createDM").mockResolvedValue({ ...mockChannel, position: 0 });
-        vi.spyOn(module.cases, "create").mockResolvedValue(mockCase);
+        vi.spyOn(module.cases, "create").mockResolvedValue(entity);
         vi.spyOn(module.cases, "getByUser").mockResolvedValue([]);
         vi.spyOn(module.moderationSettings, "getOrCreate").mockResolvedValue(settings);
     });
@@ -193,7 +186,7 @@ describe("/warn", () => {
 
             expect(createSpy).toHaveBeenCalledOnce();
             expect(createSpy).toHaveBeenCalledWith({
-                case: mockCase,
+                case: entity,
                 creator: interaction.user,
                 reason: options.reason,
                 user: options.member.user


### PR DESCRIPTION
Removes the `mockCase` from tests and replaces it with a general one.