### PR TITLE
chore: improve test speed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Uses Turbo's Remote Caching for faster tests. Also made the Server's tests much faster (and less prone to breaking) by simply mocking the callback function rather than constantly closing and opening a new server.