### PR TITLE
fix: do not show podium with less than 4 members

### DIFF
--- a/apps/barry/src/modules/leveling/commands/chatinput/leaderboard/LeaderboardCanvas.ts
+++ b/apps/barry/src/modules/leveling/commands/chatinput/leaderboard/LeaderboardCanvas.ts
@@ -81,7 +81,7 @@ export class LeaderboardCanvas {
      * Checks if the leaderboard has a podium (top three members).
      */
     get withPodium(): boolean {
-        return this.#page === 1;
+        return this.#page === 1 && this.#members.length > 3;
     }
 
     /**


### PR DESCRIPTION
The podium should not be shown when there are not enough members to show it properly. It should only show it if there are more than 3 members.