### PR TITLE
feat: implement contrast checker

### DIFF
--- a/apps/barry/package.json
+++ b/apps/barry/package.json
@@ -34,12 +34,14 @@
     "@napi-rs/canvas": "^0.1.41",
     "@prisma/client": "^5.0.0",
     "canvas-constructor": "^7.0.1",
+    "color-convert": "^2.0.1",
     "convert-units": "^2.3.4",
     "emojilib": "^2.4.0",
     "ioredis": "^5.3.2"
   },
   "devDependencies": {
     "@barry/testing": "*",
+    "@types/color-convert": "^2.0.3",
     "@types/convert-units": "^2.3.9",
     "prisma": "^5.0.0"
   }

--- a/apps/barry/src/modules/general/commands/chatinput/contrast/index.ts
+++ b/apps/barry/src/modules/general/commands/chatinput/contrast/index.ts
@@ -1,0 +1,156 @@
+import {
+    type ApplicationCommandInteraction,
+    SlashCommand,
+    SlashCommandOptionBuilder
+} from "@barry/core";
+import type GeneralModule from "../../../index.js";
+
+import { Canvas, loadFont } from "canvas-constructor/napi-rs";
+import { getContrastScore, parseColor } from "../../../functions/colors.js";
+import { MessageFlags } from "@discordjs/core";
+import { join } from "node:path";
+import config from "../../../../../config.js";
+
+loadFont(join(process.cwd(), "./assets/fonts/Inter-SemiBold.ttf"), "Inter SemiBold");
+loadFont(join(process.cwd(), "./assets/fonts/Inter-Regular.ttf"), "Inter");
+
+/**
+ * The placeholder text to use for the image.
+ */
+const PLACEHOLDER_TEXT = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+
+/**
+ * The placeholder title to use for the image.
+ */
+const PLACEHOLDER_TITLE = "Lorem Ipsum";
+
+/**
+ * The options for the contrast command.
+ */
+export interface ContrastOptions {
+    /**
+     * The background color.
+     */
+    background: string;
+
+    /**
+     * The foreground color.
+     */
+    foreground: string;
+}
+
+/**
+ * Represents a slash command to check the contrast between two colors.
+ */
+export default class extends SlashCommand<GeneralModule> {
+    /**
+     * Represents a slash command to check the contrast between two colors.
+     *
+     * @param module The module this command belongs to.
+     */
+    constructor(module: GeneralModule) {
+        super(module, {
+            name: "contrast",
+            description: "Check the contrast between two colors.",
+            options: {
+                background: SlashCommandOptionBuilder.string({
+                    description: "The background color.",
+                    required: true
+                }),
+                foreground: SlashCommandOptionBuilder.string({
+                    description: "The foreground color.",
+                    required: true
+                })
+            }
+        });
+    }
+
+    /**
+     * Checks the contrast between two colors.
+     *
+     * @param interaction The interaction that triggered this command.
+     * @param options The options for this command.
+     */
+    async execute(interaction: ApplicationCommandInteraction, options: ContrastOptions): Promise<void> {
+        const background = parseColor(options.background);
+        if (background === undefined) {
+            return interaction.createMessage({
+                content: `${config.emotes.error} That is not a valid background color.`,
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
+        const foreground = parseColor(options.foreground);
+        if (foreground === undefined) {
+            return interaction.createMessage({
+                content: `${config.emotes.error} That is not a valid foreground color.`,
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
+        const score = getContrastScore(background, foreground);
+        const feedback = this.getFeedback(score);
+
+        const canvas = new Canvas(1000, 300)
+            .setTextAlign("center")
+
+            // Background
+            .setColor(`#${background.hex}`)
+            .printRoundedRectangle(0, 0, 495, 300, 30)
+
+            // Foreground
+            .setColor(`#${foreground.hex}`)
+            .printRoundedRectangle(505, 0, 495, 300, 30)
+
+            // Background Text
+            .setColor(`#${foreground.hex}`)
+            .setTextFont("30px Inter SemiBold")
+            .printText(PLACEHOLDER_TITLE, 250, 120)
+            .setTextFont("20px Inter")
+            .printWrappedText(PLACEHOLDER_TEXT, 250, 150, 400)
+
+            // Foreground Text
+            .setColor(`#${background.hex}`)
+            .setTextFont("30px Inter SemiBold")
+            .printText(PLACEHOLDER_TITLE, 750, 120)
+            .setTextFont("20px Inter")
+            .printWrappedText(PLACEHOLDER_TEXT, 750, 150, 400);
+
+        const buffer = await canvas.pngAsync();
+        return interaction.createMessage({
+            embeds: [{
+                color: config.embedColor,
+                description: `**Contrast:** \`${score.toFixed(2)}\`\n\n${feedback}`,
+                image: {
+                    url: "attachment://contrast.png"
+                }
+            }],
+            files: [{
+                data: buffer,
+                name: "contrast.png"
+            }]
+        });
+    }
+
+    /**
+     * Gets the feedback for a contrast score.
+     *
+     * @param contrast The contrast score.
+     * @returns The feedback for the contrast score.
+     */
+    getFeedback(contrast: number): string {
+        if (contrast >= 7) {
+            return "Great choice! This color combination provides excellent contrast, making it accessible for both small and large text (AAA).";
+        }
+
+        if (contrast >= 4.5) {
+            return "Well done! This color combination offers good contrast, meeting accessibility standards for small text (AA) and exceeding them for large text (AAA).";
+        }
+
+        if (contrast >= 3) {
+            return "Not bad. This color combination has acceptable contrast for large text (AA), but falls short for small text. Consider adjusting for better accessibility.";
+        }
+
+        return "Uh-oh. This color combination has poor contrast, making it inaccessible for both small and large text. Please choose colors with better differentiation.";
+    }
+}

--- a/apps/barry/src/modules/general/functions/colors.ts
+++ b/apps/barry/src/modules/general/functions/colors.ts
@@ -1,0 +1,291 @@
+import type { KEYWORD } from "color-convert/conversions.js";
+import converter from "color-convert";
+
+/**
+ * Utility type to create a tuple for a given type and length.
+ */
+export type Tuple<T, N extends number, R extends T[] = []> = R["length"] extends N ? R : Tuple<T, N, [T, ...R]>;
+
+/**
+ * The values of a color.
+ */
+export interface ColorValues {
+    /**
+     * The cyan, magenta, yellow, and black values of the color.
+     */
+    [ColorFormat.CMYK]: [number, number, number, number];
+
+    /**
+     * The hex value of the color.
+     */
+    [ColorFormat.HEX]: string;
+
+    /**
+     * The hue, saturation, and brightness of the color.
+     */
+    [ColorFormat.HSB]: [number, number, number];
+
+    /**
+     * The hue, saturation, and lightness of the color.
+     */
+    [ColorFormat.HSL]: [number, number, number];
+
+    /**
+     * The hue, saturation, and value of the color.
+     */
+    [ColorFormat.HSV]: [number, number, number];
+
+    /**
+     * The lightness, alpha, and beta of the color.
+     */
+    [ColorFormat.LAB]: [number, number, number];
+
+    /**
+     * The red, green, and blue values of the color.
+     */
+    [ColorFormat.RGB]: [number, number, number];
+
+    /**
+     * The name of the color.
+     */
+    name: string;
+}
+
+/**
+ * The regular expression for a color in the RGB format.
+ */
+const RGB_REGEX = /rgb\((\d{1,3}), ?(\d{1,3}), ?(\d{1,3})\)/;
+
+/**
+ * The regular expression for a color in the HEX format.
+ */
+const HEX_REGEX = /(#|0x)?[0-9a-fA-F]{3,8}/;
+
+/**
+ * The regular expression for a color in the HSL format.
+ */
+const HSL_REGEX = /hsl\((\d{1,3}), ?(\d{1,3}), ?(\d{1,3})\)/;
+
+/**
+ * The regular expression for a color in the HSV format.
+ */
+const HSV_REGEX = /hsv\((\d{1,3}), ?(\d{1,3}), ?(\d{1,3})\)/;
+
+/**
+ * The regular expression for a color in the HSB format.
+ */
+const HSB_REGEX = /hsb\((\d{1,3}), ?(\d{1,3}), ?(\d{1,3})\)/;
+
+/**
+ * The regular expression for a color in the LAB format.
+ */
+const LAB_REGEX = /lab\((\d{1,3})(\.\d+)?, ?(\d{1,3})(\.\d+)?, ?(\d{1,3})(\.\d+)?\)/;
+
+/**
+ * The regular expression for a color in the CMYK format.
+ */
+const CMYK_REGEX = /cmyk\((\d{1,3}), ?(\d{1,3}), ?(\d{1,3}), ?(\d{1,3})\)?/;
+
+/**
+ * The supported color formats.
+ */
+export enum ColorFormat {
+    RGB = "rgb",
+    HSV = "hsv",
+    HSL = "hsl",
+    HSB = "hsb",
+    LAB = "lab",
+    HEX = "hex",
+    CMYK = "cmyk"
+}
+
+/**
+ * Parses the format of a color.
+ *
+ * @param value The color to parse.
+ * @returns The format of the color.
+ */
+function parseFormat(value: string): ColorFormat | undefined {
+    if (RGB_REGEX.test(value)) {
+        return ColorFormat.RGB;
+    }
+
+    if (HSL_REGEX.test(value)) {
+        return ColorFormat.HSL;
+    }
+
+    if (HSV_REGEX.test(value)) {
+        return ColorFormat.HSV;
+    }
+
+    if (HSB_REGEX.test(value)) {
+        return ColorFormat.HSB;
+    }
+
+    if (LAB_REGEX.test(value)) {
+        return ColorFormat.LAB;
+    }
+
+    if (CMYK_REGEX.test(value)) {
+        return ColorFormat.CMYK;
+    }
+
+    if (HEX_REGEX.test(value)) {
+        return ColorFormat.HEX;
+    }
+}
+
+/**
+ * Normalizes a HEX value.
+ *
+ * @param value The HEX value to normalize.
+ * @returns The normalized HEX value.
+ */
+function normalizeHEX(value: string): string {
+    value = value.replace(/^#|0x/g, "");
+
+    if (value.length === 3) {
+        value = value.replace(/./g, (char) => char + char);
+    }
+
+    return value.slice(0, 6).padEnd(6, "0");
+}
+
+/**
+ * Parses a color.
+ *
+ * @param value The color to parse.
+ * @returns The parsed color.
+ */
+function fromHEX(value: string): ColorValues {
+    const hex = normalizeHEX(value);
+
+    return {
+        [ColorFormat.CMYK]: converter.hex.cmyk(hex),
+        [ColorFormat.HEX]: hex,
+        [ColorFormat.HSB]: converter.hex.hsv(hex),
+        [ColorFormat.HSL]: converter.hex.hsl(hex),
+        [ColorFormat.HSV]: converter.hex.hsv(hex),
+        [ColorFormat.LAB]: converter.hex.lab(hex),
+        [ColorFormat.RGB]: converter.hex.rgb(hex),
+        name: converter.hex.keyword(hex)
+    };
+}
+
+/**
+ * Checks if a value is a tuple of a given length.
+ *
+ * @param value The value to check.
+ * @param length The length of the tuple.
+ * @returns Whether the value is a tuple of the given length.
+ */
+function isLength<T, N extends number>(value: T[], length: N): value is Tuple<T, N> {
+    return value.length === length;
+}
+
+/**
+ * Parses a color from a string.
+ *
+ * @param value The string to parse.
+ * @returns The parsed color.
+ */
+export function parseColor(value: string): ColorValues | undefined {
+    const format = parseFormat(value);
+    if (format === undefined) {
+        const rgb = converter.keyword.rgb(value as KEYWORD);
+        return rgb !== undefined
+            ? fromHEX(converter.rgb.hex(rgb))
+            : undefined;
+    }
+
+    if (format === ColorFormat.HEX) {
+        return fromHEX(value);
+    }
+
+    const values = value
+        .replace(format, "")
+        .replace(/[()]/g, "")
+        .split(",")
+        .map((value) => parseInt(value));
+
+    switch (format) {
+        case ColorFormat.CMYK: {
+            if (!isLength(values, converter.cmyk.channels)) {
+                throw new Error("Invalid CMYK color.");
+            }
+
+            return fromHEX(converter.cmyk.hex(values));
+        }
+        case ColorFormat.HSB: {
+            if (!isLength(values, converter.hsv.channels)) {
+                throw new Error("Invalid HSB color.");
+            }
+
+            return fromHEX(converter.hsv.hex(values));
+        }
+        case ColorFormat.HSL: {
+            if (!isLength(values, converter.hsl.channels)) {
+                throw new Error("Invalid HSL color.");
+            }
+
+            return fromHEX(converter.hsl.hex(values));
+        }
+        case ColorFormat.HSV: {
+            if (!isLength(values, converter.hsv.channels)) {
+                throw new Error("Invalid HSV color.");
+            }
+
+            return fromHEX(converter.hsv.hex(values));
+        }
+        case ColorFormat.LAB: {
+            if (!isLength(values, converter.lab.channels)) {
+                throw new Error("Invalid LAB color.");
+            }
+
+            return fromHEX(converter.lab.hex(values));
+        }
+        case ColorFormat.RGB: {
+            if (!isLength(values, converter.rgb.channels)) {
+                throw new Error("Invalid RGB color.");
+            }
+
+            return fromHEX(converter.rgb.hex(values));
+        }
+    }
+}
+
+/**
+ * Gets the luminance of a color.
+ *
+ * @param rgb The RGB values of the color.
+ * @returns The luminance of the color.
+ */
+function getLuminance(rgb: ColorValues[ColorFormat.RGB]): number {
+    const [r, g, b] = rgb.map((value) => {
+        value /= 255;
+
+        return value > 0.03928
+            ? ((value + 0.055) / 1.055) ** 2.4
+            : value / 12.92;
+    });
+
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/**
+ * Gets the contrast score of two colors.
+ *
+ * @param background The background color.
+ * @param foreground The foreground color.
+ * @returns The contrast score of the two colors.
+ */
+export function getContrastScore(background: ColorValues, foreground: ColorValues): number {
+    const backgroundLuminance = getLuminance(background[ColorFormat.RGB]);
+    const foregroundLuminance = getLuminance(foreground[ColorFormat.RGB]);
+
+    if (backgroundLuminance > foregroundLuminance) {
+        return (backgroundLuminance + 0.05) / (foregroundLuminance + 0.05);
+    }
+
+    return (foregroundLuminance + 0.05) / (backgroundLuminance + 0.05);
+}

--- a/apps/barry/src/modules/general/functions/colors.ts
+++ b/apps/barry/src/modules/general/functions/colors.ts
@@ -54,37 +54,37 @@ export interface ColorValues {
 /**
  * The regular expression for a color in the RGB format.
  */
-const RGB_REGEX = /rgb\((\d{1,3}), ?(\d{1,3}), ?(\d{1,3})\)/;
+const RGB_REGEX = /^rgb\((\d{1,3}), ?(\d{1,3}), ?(\d{1,3})\)/;
 
 /**
  * The regular expression for a color in the HEX format.
  */
-const HEX_REGEX = /(#|0x)?[0-9a-fA-F]{3,8}/;
+const HEX_REGEX = /^(#|0x)?[0-9a-fA-F]{3,8}/;
 
 /**
  * The regular expression for a color in the HSL format.
  */
-const HSL_REGEX = /hsl\((\d{1,3}), ?(\d{1,3}), ?(\d{1,3})\)/;
+const HSL_REGEX = /^hsl\((\d{1,3}), ?(\d{1,3}), ?(\d{1,3})\)/;
 
 /**
  * The regular expression for a color in the HSV format.
  */
-const HSV_REGEX = /hsv\((\d{1,3}), ?(\d{1,3}), ?(\d{1,3})\)/;
+const HSV_REGEX = /^hsv\((\d{1,3}), ?(\d{1,3}), ?(\d{1,3})\)/;
 
 /**
  * The regular expression for a color in the HSB format.
  */
-const HSB_REGEX = /hsb\((\d{1,3}), ?(\d{1,3}), ?(\d{1,3})\)/;
+const HSB_REGEX = /^hsb\((\d{1,3}), ?(\d{1,3}), ?(\d{1,3})\)/;
 
 /**
  * The regular expression for a color in the LAB format.
  */
-const LAB_REGEX = /lab\((\d{1,3})(\.\d+)?, ?(\d{1,3})(\.\d+)?, ?(\d{1,3})(\.\d+)?\)/;
+const LAB_REGEX = /^lab\((\d{1,3})(\.\d+)?, ?(\d{1,3})(\.\d+)?, ?(\d{1,3})(\.\d+)?\)/;
 
 /**
  * The regular expression for a color in the CMYK format.
  */
-const CMYK_REGEX = /cmyk\((\d{1,3}), ?(\d{1,3}), ?(\d{1,3}), ?(\d{1,3})\)?/;
+const CMYK_REGEX = /^cmyk\((\d{1,3}), ?(\d{1,3}), ?(\d{1,3}), ?(\d{1,3})\)?/;
 
 /**
  * The supported color formats.

--- a/apps/barry/tests/modules/general/commands/chatinput/contrast/index.test.ts
+++ b/apps/barry/tests/modules/general/commands/chatinput/contrast/index.test.ts
@@ -1,0 +1,117 @@
+import type { Canvas } from "canvas-constructor/napi-rs";
+
+import { ApplicationCommandInteraction } from "@barry/core";
+import { MessageFlags } from "@discordjs/core";
+import { createMockApplication } from "../../../../../mocks/index.js";
+import { createMockApplicationCommandInteraction } from "@barry/testing";
+
+import ContrastCommand from "../../../../../../src/modules/general/commands/chatinput/contrast/index.js";
+import GeneralModule from "../../../../../../src/modules/general/index.js";
+
+vi.mock("canvas-constructor/napi-rs", () => {
+    const MockCanvas: typeof Canvas = vi.fn();
+    MockCanvas.prototype.printRoundedRectangle = vi.fn().mockReturnThis();
+    MockCanvas.prototype.printWrappedText = vi.fn().mockReturnThis();
+    MockCanvas.prototype.printText = vi.fn().mockReturnThis();
+    MockCanvas.prototype.setColor = vi.fn().mockReturnThis();
+    MockCanvas.prototype.setTextAlign = vi.fn().mockReturnThis();
+    MockCanvas.prototype.setTextFont = vi.fn().mockReturnThis();
+    MockCanvas.prototype.pngAsync = vi.fn().mockResolvedValue(Buffer.from("Hello World"));
+
+    return {
+        Canvas: MockCanvas,
+        loadFont: vi.fn(),
+        loadImage: vi.fn()
+    };
+});
+
+describe("ContrastCommand", () => {
+    let command: ContrastCommand;
+    let interaction: ApplicationCommandInteraction;
+
+    beforeEach(() => {
+        const client = createMockApplication();
+        const module = new GeneralModule(client);
+        command = new ContrastCommand(module);
+
+        const data = createMockApplicationCommandInteraction();
+        interaction = new ApplicationCommandInteraction(data, client, vi.fn());
+        interaction.createMessage = vi.fn();
+    });
+
+    describe("execute", () => {
+        it("should send the result of the contrast check", async () => {
+            await command.execute(interaction, {
+                background: "#000000",
+                foreground: "#ffffff"
+            });
+
+            expect(interaction.createMessage).toHaveBeenCalledOnce();
+            expect(interaction.createMessage).toHaveBeenCalledWith({
+                embeds: [{
+                    color: expect.any(Number),
+                    description: expect.stringContaining("**Contrast:** `21.00`"),
+                    image: {
+                        url: "attachment://contrast.png"
+                    }
+                }],
+                files: [{
+                    data: Buffer.from("Hello World"),
+                    name: "contrast.png"
+                }]
+            });
+        });
+
+        it("should send an error message if the background color is invalid", async () => {
+            await command.execute(interaction, {
+                background: "invalid",
+                foreground: "#ffffff"
+            });
+
+            expect(interaction.createMessage).toHaveBeenCalledOnce();
+            expect(interaction.createMessage).toHaveBeenCalledWith({
+                content: expect.stringContaining("That is not a valid background color."),
+                flags: MessageFlags.Ephemeral
+            });
+        });
+
+        it("should send an error message if the foreground color is invalid", async () => {
+            await command.execute(interaction, {
+                background: "#000000",
+                foreground: "invalid"
+            });
+
+            expect(interaction.createMessage).toHaveBeenCalledOnce();
+            expect(interaction.createMessage).toHaveBeenCalledWith({
+                content: expect.stringContaining("That is not a valid foreground color."),
+                flags: MessageFlags.Ephemeral
+            });
+        });
+    });
+
+    describe("getFeedback", () => {
+        it("should return great feedback if the score is greater than 7", () => {
+            const feedback = command.getFeedback(7);
+
+            expect(feedback).toContain("Great choice!");
+        });
+
+        it("should return good feedback if the score is greater than 4.5", () => {
+            const feedback = command.getFeedback(4.5);
+
+            expect(feedback).toContain("Well done!");
+        });
+
+        it("should return okay feedback if the score is less than 4.5", () => {
+            const feedback = command.getFeedback(4);
+
+            expect(feedback).toContain("Not bad.");
+        });
+
+        it("should return bad feedback if the score is less than 3", () => {
+            const feedback = command.getFeedback(2);
+
+            expect(feedback).toContain("Uh-oh.");
+        });
+    });
+});

--- a/apps/barry/tests/modules/general/functions/colors.test.ts
+++ b/apps/barry/tests/modules/general/functions/colors.test.ts
@@ -1,0 +1,107 @@
+import { type ColorValues, getContrastScore, parseColor } from "../../../../src/modules/general/functions/colors.js";
+
+describe("parseColor", () => {
+    it("should parse a hex color", () => {
+        const color = parseColor("#FFFFFF");
+
+        expect(color).toContain({
+            hex: "FFFFFF"
+        });
+    });
+
+    it("should parse a color by its name", () => {
+        const color = parseColor("white");
+
+        expect(color).toContain({
+            hex: "FFFFFF"
+        });
+    });
+
+    it("should parse a rgb color", () => {
+        const color = parseColor("rgb(255, 255, 255)");
+
+        expect(color).toContain({
+            hex: "FFFFFF"
+        });
+    });
+
+    it("should parse a hsl color", () => {
+        const color = parseColor("hsl(0, 0, 100)");
+
+        expect(color).toContain({
+            hex: "FFFFFF"
+        });
+    });
+
+    it("should parse a hsv color", () => {
+        const color = parseColor("hsv(0, 0, 100)");
+
+        expect(color).toContain({
+            hex: "FFFFFF"
+        });
+    });
+
+    it("should parse a hsb color", () => {
+        const color = parseColor("hsb(0, 0, 100)");
+
+        expect(color).toContain({
+            hex: "FFFFFF"
+        });
+    });
+
+    it("should parse a lab color", () => {
+        const color = parseColor("lab(100, 0, 0)");
+
+        expect(color).toContain({
+            hex: "FFFFFF"
+        });
+    });
+
+    it("should parse a cmyk color", () => {
+        const color = parseColor("cmyk(0, 0, 0, 0)");
+
+        expect(color).toContain({
+            hex: "FFFFFF"
+        });
+    });
+
+    it("should return undefined if the color is invalid", () => {
+        const color = parseColor("invalid");
+
+        expect(color).toBeUndefined();
+    });
+});
+
+describe("getContrastScore", () => {
+    it("should return the correct score if the background is white", () => {
+        const background = { rgb: [255, 255, 255] } as ColorValues;
+        const foreground = { rgb: [0, 0, 0] } as ColorValues;
+        const score = getContrastScore(background, foreground);
+
+        expect(score).toBe(21);
+    });
+
+    it("should return the correct score if the background is black", () => {
+        const background = { rgb: [0, 0, 0] } as ColorValues;
+        const foreground = { rgb: [255, 255, 255] } as ColorValues;
+        const score = getContrastScore(background, foreground);
+
+        expect(score).toBe(21);
+    });
+
+    it("should return the correct score if the background is red", () => {
+        const background = { rgb: [255, 0, 0] } as ColorValues;
+        const foreground = { rgb: [0, 0, 0] } as ColorValues;
+        const score = getContrastScore(background, foreground);
+
+        expect(score.toFixed(2)).toBe("5.25");
+    });
+
+    it("should return the correct score if the background is green", () => {
+        const background = { rgb: [0, 255, 0] } as ColorValues;
+        const foreground = { rgb: [0, 0, 0] } as ColorValues;
+        const score = getContrastScore(background, foreground);
+
+        expect(score.toFixed(2)).toBe("15.30");
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,12 +42,14 @@
         "@napi-rs/canvas": "^0.1.41",
         "@prisma/client": "^5.0.0",
         "canvas-constructor": "^7.0.1",
+        "color-convert": "^2.0.1",
         "convert-units": "^2.3.4",
         "emojilib": "^2.4.0",
         "ioredis": "^5.3.2"
       },
       "devDependencies": {
         "@barry/testing": "*",
+        "@types/color-convert": "^2.0.3",
         "@types/convert-units": "^2.3.9",
         "prisma": "^5.0.0"
       },
@@ -1129,6 +1131,21 @@
         "@types/chai": "*"
       }
     },
+    "node_modules/@types/color-convert": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.3.tgz",
+      "integrity": "sha512-2Q6wzrNiuEvYxVQqhh7sXM2mhIhvZR/Paq4FdsQkOMgWsCIkKvSGj8Le1/XalulrmgOzPMqNa0ix+ePY4hTrfg==",
+      "dev": true,
+      "dependencies": {
+        "@types/color-name": "*"
+      }
+    },
+    "node_modules/@types/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-87W6MJCKZYDhLAx/J1ikW8niMvmGRyY+rpUxWpL1cO7F8Uu5CHuQoFv+R0/L5pgNdW4jTyda42kv60uwVIPjLw==",
+      "dev": true
+    },
     "node_modules/@types/convert-units": {
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@types/convert-units/-/convert-units-2.3.9.tgz",
@@ -1858,8 +1875,8 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -1869,7 +1886,6 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -5616,6 +5632,21 @@
         "@types/chai": "*"
       }
     },
+    "@types/color-convert": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.3.tgz",
+      "integrity": "sha512-2Q6wzrNiuEvYxVQqhh7sXM2mhIhvZR/Paq4FdsQkOMgWsCIkKvSGj8Le1/XalulrmgOzPMqNa0ix+ePY4hTrfg==",
+      "dev": true,
+      "requires": {
+        "@types/color-name": "*"
+      }
+    },
+    "@types/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-87W6MJCKZYDhLAx/J1ikW8niMvmGRyY+rpUxWpL1cO7F8Uu5CHuQoFv+R0/L5pgNdW4jTyda42kv60uwVIPjLw==",
+      "dev": true
+    },
     "@types/convert-units": {
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@types/convert-units/-/convert-units-2.3.9.tgz",
@@ -5945,8 +5976,10 @@
         "@discordjs/ws": "^1.0.2",
         "@napi-rs/canvas": "^0.1.41",
         "@prisma/client": "^5.0.0",
+        "@types/color-convert": "^2.0.3",
         "@types/convert-units": "^2.3.9",
         "canvas-constructor": "^7.0.1",
+        "color-convert": "^2.0.1",
         "convert-units": "^2.3.4",
         "emojilib": "^2.4.0",
         "ioredis": "^5.3.2",
@@ -6071,14 +6104,14 @@
     },
     "color-convert": {
       "version": "2.0.1",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "requires": {
         "color-name": "~1.1.4"
       }
     },
     "color-name": {
-      "version": "1.1.4",
-      "dev": true
+      "version": "1.1.4"
     },
     "concat-map": {
       "version": "0.0.1",


### PR DESCRIPTION
Adds a command to easily check the contrast between two colors. For more information: https://en.wikipedia.org/wiki/Web_Content_Accessibility_Guidelines