### PR TITLE
fix: uppercase currency in convert

### DIFF
--- a/apps/barry/src/modules/general/commands/chatinput/convert/currency/index.ts
+++ b/apps/barry/src/modules/general/commands/chatinput/convert/currency/index.ts
@@ -185,7 +185,7 @@ export default class extends SlashCommand<GeneralModule> {
             });
         }
 
-        const rate = await this.fetchRate(options.amount, options.from, options.to);
+        const rate = await this.fetchRate(options.amount, options.from.toUpperCase(), options.to.toUpperCase());
         await interaction.createMessage({
             content: `${config.emotes.add} \`${options.amount} ${options.from}\` is \`${rate} ${options.to}\`.`
         });


### PR DESCRIPTION
It does validate with uppercase characters, but does not pass them as uppercase. No idea who merged this :eyes: 