### PR TITLE
fix: small bug fixes (convert, report onDelete)

### DIFF
--- a/apps/barry/prisma/schema.prisma
+++ b/apps/barry/prisma/schema.prisma
@@ -223,8 +223,8 @@ model Report {
   createdAt DateTime       @default(now()) @map("created_at")
 
   local     LocalReport[]
-  profile   Profile?       @relation(references: [userID], fields: [userID], onDelete: Cascade)
-  request   Request?       @relation(references: [id], fields: [requestID], onDelete: Cascade)
+  profile   Profile?       @relation(references: [userID], fields: [userID])
+  request   Request?       @relation(references: [id], fields: [requestID])
 
   @@map("reports")
 }

--- a/apps/barry/src/modules/general/commands/chatinput/convert/currency/index.ts
+++ b/apps/barry/src/modules/general/commands/chatinput/convert/currency/index.ts
@@ -164,6 +164,9 @@ export default class extends SlashCommand<GeneralModule> {
      * @param options The options for this command.
      */
     async execute(interaction: ApplicationCommandInteraction, options: CurrencyOptions): Promise<void> {
+        options.from = options.from.toUpperCase();
+        options.to = options.to.toUpperCase();
+
         if (!this.isValidCurrency(options.from)) {
             return interaction.createMessage({
                 content: `${config.emotes.error} \`${options.from}\` is not a valid currency.`,
@@ -185,7 +188,7 @@ export default class extends SlashCommand<GeneralModule> {
             });
         }
 
-        const rate = await this.fetchRate(options.amount, options.from.toUpperCase(), options.to.toUpperCase());
+        const rate = await this.fetchRate(options.amount, options.from, options.to);
         await interaction.createMessage({
             content: `${config.emotes.add} \`${options.amount} ${options.from}\` is \`${rate} ${options.to}\`.`
         });
@@ -217,7 +220,7 @@ export default class extends SlashCommand<GeneralModule> {
      * @returns Whether the given currency is valid.
      */
     isValidCurrency(currency: string): boolean {
-        return currency.toUpperCase() in currencyNames;
+        return currency in currencyNames;
     }
 
     /**

--- a/apps/barry/tests/modules/general/commands/chatinput/convert/currency/index.test.ts
+++ b/apps/barry/tests/modules/general/commands/chatinput/convert/currency/index.test.ts
@@ -50,7 +50,7 @@ describe("/convert currency", () => {
 
             expect(interaction.createMessage).toHaveBeenCalledOnce();
             expect(interaction.createMessage).toHaveBeenCalledWith({
-                content: expect.stringContaining("`invalid` is not a valid currency."),
+                content: expect.stringContaining("`INVALID` is not a valid currency."),
                 flags: MessageFlags.Ephemeral
             });
         });
@@ -68,7 +68,7 @@ describe("/convert currency", () => {
 
             expect(interaction.createMessage).toHaveBeenCalledOnce();
             expect(interaction.createMessage).toHaveBeenCalledWith({
-                content: expect.stringContaining("`invalid` is not a valid currency."),
+                content: expect.stringContaining("`INVALID` is not a valid currency."),
                 flags: MessageFlags.Ephemeral
             });
         });


### PR DESCRIPTION
The `onDelete` on report relations was set to `Cascade`, perhaps not the smartest idea. And I'm editing the uppercase stuff from convert currencies once again.