### PR TITLE
fix: dwc missing member option

### DIFF
--- a/apps/barry/src/modules/moderation/commands/chatinput/dwc/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/dwc/index.ts
@@ -49,6 +49,13 @@ export default class extends SlashCommand<ModerationModule> {
      * @param options The options for the command.
      */
     async execute(interaction: ApplicationCommandInteraction, options: DWCOptions): Promise<void> {
+        if ("members" in interaction.data.resolved) {
+            const member = interaction.data.resolved.members.get(options.user.id);
+            if (member !== undefined) {
+                options.member = member;
+            }
+        }
+
         return this.module.actions.dwc(interaction, options);
     }
 }


### PR DESCRIPTION
Deal With Caution requires the member in order to assign the role. The command itself did not pass it.