### PR TITLE
fix: update core to cascade permissions

### DIFF
--- a/apps/barry/src/modules/moderation/commands/chatinput/cases/delete/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/cases/delete/index.ts
@@ -37,7 +37,7 @@ export default class extends SlashCommand<ModerationModule> {
         super(module, {
             name: "delete",
             description: "Delete a specific case.",
-            defaultMemberPermissions: PermissionFlagsBits.ManageGuild,
+            defaultMemberPermissions: PermissionFlagsBits.ModerateMembers,
             guildOnly: true,
             options: {
                 case: SlashCommandOptionBuilder.integer({

--- a/packages/core/src/commands/BaseCommand.ts
+++ b/packages/core/src/commands/BaseCommand.ts
@@ -139,7 +139,9 @@ export abstract class BaseCommand<M extends Module = Module> {
     /**
      * Initializes the command.
      */
-    async initialize(): Promise<void> {}
+    async initialize(): Promise<void> {
+        // Empty...
+    }
 
     /**
      * Returns an object with the properties required to register a new command.

--- a/packages/core/src/commands/BaseCommand.ts
+++ b/packages/core/src/commands/BaseCommand.ts
@@ -137,6 +137,11 @@ export abstract class BaseCommand<M extends Module = Module> {
     }
 
     /**
+     * Initializes the command.
+     */
+    async initialize(): Promise<void> {}
+
+    /**
      * Returns an object with the properties required to register a new command.
      */
     toJSON(): RESTPostAPIApplicationCommandsJSONBody {

--- a/packages/core/src/commands/SlashCommand.ts
+++ b/packages/core/src/commands/SlashCommand.ts
@@ -157,7 +157,7 @@ export abstract class SlashCommand<M extends Module = Module> extends BaseComman
     /**
      * Registers a subcommand.
      *
-     * @param child The subcommand to register. 
+     * @param child The subcommand to register.
      */
     #registerChild(child: SlashCommand<M>): void {
         if (child.defaultMemberPermissions !== undefined) {

--- a/packages/core/src/commands/SlashCommand.ts
+++ b/packages/core/src/commands/SlashCommand.ts
@@ -25,11 +25,11 @@ type ApplicationCommandSubcommandOption =
 /**
  * Options for a {@link SlashCommand}.
  */
-export interface SlashCommandOptions extends ApplicationCommandOptions {
+export interface SlashCommandOptions<M extends Module = Module> extends ApplicationCommandOptions {
     /**
      * The subcommands of the command.
      */
-    children?: ConstructorArray<SlashCommand>;
+    children?: ConstructorArray<SlashCommand<M>>;
 
     /**
      * A description of the command.
@@ -78,32 +78,22 @@ export abstract class SlashCommand<M extends Module = Module> extends BaseComman
     type: ApplicationCommandType.ChatInput = ApplicationCommandType.ChatInput;
 
     /**
+     * An array of commands to register during initialization.
+     */
+    #toRegister: ConstructorArray<SlashCommand<M>>;
+
+    /**
      * Represents a slash command.
      *
      * @param module The module this command belong to.
      * @param options Options for the command.
      */
-    constructor(module: M, options: SlashCommandOptions) {
+    constructor(module: M, options: SlashCommandOptions<M>) {
         super(module, options);
 
         this.description = options.description;
         this.descriptionLocalizations = options.descriptionLocalizations;
-
-        if (Array.isArray(options.children)) {
-            for (const CommandClass of options.children) {
-                const instance = new CommandClass(module) as SlashCommand<M>;
-
-                this.children.set(instance.name, instance);
-            }
-        } else if (options.children !== undefined) {
-            options.children.then((children) => {
-                for (const CommandClass of children) {
-                    const instance = new CommandClass(module) as SlashCommand<M>;
-
-                    this.children.set(instance.name, instance);
-                }
-            });
-        }
+        this.#toRegister = options.children ?? [];
 
         if (options.options !== undefined) {
             for (const key in options.options) {
@@ -145,6 +135,13 @@ export abstract class SlashCommand<M extends Module = Module> extends BaseComman
     }
 
     /**
+     * Initializes the command.
+     */
+    override async initialize(): Promise<void> {
+        await this.#registerChildren(this.#toRegister);
+    }
+
+    /**
      * Returns an object with the properties required to register a new command.
      */
     toJSON(): RESTPostAPIApplicationCommandsJSONBody {
@@ -155,6 +152,34 @@ export abstract class SlashCommand<M extends Module = Module> extends BaseComman
             description_localizations: this.descriptionLocalizations,
             options: this.getOptions()
         });
+    }
+
+    /**
+     * Registers a subcommand.
+     *
+     * @param child The subcommand to register. 
+     */
+    #registerChild(child: SlashCommand<M>): void {
+        if (child.defaultMemberPermissions !== undefined) {
+            this.defaultMemberPermissions ??= 0n;
+            this.defaultMemberPermissions |= child.defaultMemberPermissions;
+        }
+
+        this.children.set(child.name, child);
+    }
+
+    /**
+     * Registers all the children of the command.
+     *
+     * @param children The children to register.
+     */
+    async #registerChildren(children: ConstructorArray<SlashCommand<M>>): Promise<void> {
+        for (const CommandClass of await children) {
+            const command = new CommandClass(this.module);
+            await command.initialize();
+
+            this.#registerChild(command);
+        }
     }
 
     /**

--- a/packages/core/src/modules/Module.ts
+++ b/packages/core/src/modules/Module.ts
@@ -169,7 +169,10 @@ export abstract class Module<T extends Client = Client> {
      */
     async #loadCommands(commands: ConstructorArray<AnyCommand>): Promise<void> {
         for (const CommandClass of await commands) {
-            this.commands.push(new CommandClass(this));
+            const command = new CommandClass(this);
+            await command.initialize();
+
+            this.commands.push(command);
         }
     }
 

--- a/packages/core/tests/commands/SlashCommand.test.ts
+++ b/packages/core/tests/commands/SlashCommand.test.ts
@@ -36,8 +36,9 @@ describe("SlashCommand", () => {
     });
 
     describe("constructor", () => {
-        it("should initialize the command with the provided options", () => {
+        it("should initialize the command with the provided options", async () => {
             const command = new MockSlashCommand(module, slashCommandOptions);
+            await command.initialize();
 
             expect(command.description).toBe(slashCommandOptions.description);
             expect(command.descriptionLocalizations).toEqual(slashCommandOptions.descriptionLocalizations);
@@ -57,28 +58,25 @@ describe("SlashCommand", () => {
                 }
             ]);
         });
+    });
 
-        it("should add subcommands when provided as an array", () => {
+    describe("initialize", () => {
+        it("should register the command's subcommands", async () => {
             const command = new MockSlashCommand(module, slashCommandOptions);
 
-            expect(command.children.get("foo")).toBeInstanceOf(MockSlashCommandFoo);
-            expect(command.children.get("bar")).toBeInstanceOf(MockSlashCommandBar);
-        });
+            expect(command.children.size).toBe(0);
 
-        it("should add subcommands when provided as a promise", async () => {
-            const children = Promise.resolve([MockSlashCommandFoo, MockSlashCommandBar]);
-            const command = new MockSlashCommand(module, { ...slashCommandOptions, children });
+            await command.initialize();
 
-            await children;
-
-            expect(command.children.get("foo")).toBeInstanceOf(MockSlashCommandFoo);
-            expect(command.children.get("bar")).toBeInstanceOf(MockSlashCommandBar);
+            expect(command.children.size).toBeGreaterThan(0);
         });
     });
 
     describe("toJSON", () => {
-        it("should return the JSON representation of the command", () => {
+        it("should return the JSON representation of the command", async () => {
             const command = new MockSlashCommand(module, slashCommandOptions);
+            await command.initialize();
+
             const payload = command.toJSON();
 
             expect(payload).toEqual({

--- a/packages/core/tests/commands/SlashCommand.test.ts
+++ b/packages/core/tests/commands/SlashCommand.test.ts
@@ -8,8 +8,6 @@ import { type Module, Client } from "../../src/index.js";
 import {
     MockModule,
     MockSlashCommand,
-    MockSlashCommandBar,
-    MockSlashCommandFoo,
     baseSlashCommandOptions,
     slashCommandOptions
 } from "../mocks/index.js";

--- a/packages/core/tests/services/commands/CommandService.test.ts
+++ b/packages/core/tests/services/commands/CommandService.test.ts
@@ -89,11 +89,13 @@ describe("CommandService", () => {
     });
 
     describe("get", () => {
-        it("should return a registered global command", () => {
+        it("should return a registered global command", async () => {
             const data = createMockApplicationCommandInteraction();
             const command = new MockSlashCommand(module, {
                 name: data.data.name
             });
+
+            await command.initialize();
 
             commands.add(command);
             const interaction = new ApplicationCommandInteraction(data, client);
@@ -102,7 +104,7 @@ describe("CommandService", () => {
             expect(commands.get(interaction)).toBe(command);
         });
 
-        it("should return a registered guild command", () => {
+        it("should return a registered guild command", async () => {
             const data = createMockApplicationCommandInteraction({
                 ...mockChatInputCommand,
                 guild_id: "68239102456844360"
@@ -112,16 +114,16 @@ describe("CommandService", () => {
                 name: data.data.name,
                 guilds: ["68239102456844360", "30527482987641765"]
             });
+            await command.initialize();
 
             commands.add(command);
-
             const interaction = new ApplicationCommandInteraction(data, client);
 
             expect(commands.size).toBe(2);
             expect(commands.get(interaction)).toBe(command);
         });
 
-        it("should return a registered subcommand", () => {
+        it("should return a registered subcommand", async () => {
             const data = createMockApplicationCommandInteraction({
                 ...mockChatInputCommand,
                 options: [{
@@ -139,47 +141,51 @@ describe("CommandService", () => {
                 children: [MockSlashCommandFoo, MockSlashCommandBar]
             });
 
-            commands.add(command);
+            await command.initialize();
 
+            commands.add(command);
             const interaction = new ApplicationCommandInteraction(data, client);
 
             expect(commands.size).toBe(1);
             expect(commands.get(interaction)).toBeInstanceOf(MockSlashCommandFooBar);
         });
 
-        it("should return a message command", () => {
+        it("should return a message command", async () => {
             const data = createMockApplicationCommandInteraction(mockMessageCommand);
             const command = new MockMessageCommand(module, {
                 name: data.data.name
             });
 
-            commands.add(command);
+            await command.initialize();
 
+            commands.add(command);
             const interaction = new ApplicationCommandInteraction(data, client);
 
             expect(commands.size).toBe(1);
             expect(commands.get(interaction)).toBe(command);
         });
 
-        it("should return a user command", () => {
+        it("should return a user command", async () => {
             const data = createMockApplicationCommandInteraction(mockUserCommand);
             const command = new MockUserCommand(module, {
                 name: data.data.name
             });
 
-            commands.add(command);
+            await command.initialize();
 
+            commands.add(command);
             const interaction = new ApplicationCommandInteraction(data, client);
 
             expect(commands.size).toBe(1);
             expect(commands.get(interaction)).toBe(command);
         });
 
-        it("should throw an error if the command type is not expected", () => {
+        it("should throw an error if the command type is not expected", async () => {
             const data = createMockApplicationCommandInteraction();
             const command = new MockSlashCommand(module, {
                 name: data.data.name
             });
+            await command.initialize();
 
             commands.add(command);
             command.type = ApplicationCommandType.User as ApplicationCommandType.ChatInput;


### PR DESCRIPTION
There seemed to be a bug with permissions not cascading to their parent. 