### PR TITLE
feat: add support for user-installable apps

### DIFF
--- a/apps/barry/package.json
+++ b/apps/barry/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@barry-bot/core": "*",
     "@discordjs/core": "^1.3.0-dev.1721153953-efa16a609",
-    "@discordjs/rest": "^2.4.0-dev.1721153952-efa16a609",
+    "@discordjs/rest": "^2.3.0",
     "@discordjs/ws": "^1.2.0-dev.1721153959-efa16a609",
     "@napi-rs/canvas": "^0.1.41",
     "@prisma/client": "^5.0.0",

--- a/apps/barry/package.json
+++ b/apps/barry/package.json
@@ -28,9 +28,9 @@
   },
   "dependencies": {
     "@barry-bot/core": "*",
-    "@discordjs/core": "^1.1.1",
-    "@discordjs/rest": "^2.2.0",
-    "@discordjs/ws": "^1.0.2",
+    "@discordjs/core": "^1.3.0-dev.1721153953-efa16a609",
+    "@discordjs/rest": "^2.4.0-dev.1721153952-efa16a609",
+    "@discordjs/ws": "^1.2.0-dev.1721153959-efa16a609",
     "@napi-rs/canvas": "^0.1.41",
     "@prisma/client": "^5.0.0",
     "canvas-constructor": "^7.0.1",

--- a/apps/barry/src/modules/general/commands/chatinput/color/index.ts
+++ b/apps/barry/src/modules/general/commands/chatinput/color/index.ts
@@ -5,8 +5,8 @@ import {
 } from "@barry-bot/core";
 import type GeneralModule from "../../../index.js";
 
+import { ApplicationIntegrationType, MessageFlags } from "@discordjs/core";
 import { Canvas } from "canvas-constructor/napi-rs";
-import { MessageFlags } from "@discordjs/core";
 import { parseColor } from "../../../functions/colors.js";
 import config from "../../../../../config.js";
 
@@ -33,6 +33,7 @@ export default class extends SlashCommand<GeneralModule> {
         super(module, {
             name: "color",
             description: "Shows information about a color.",
+            integrationTypes: [ApplicationIntegrationType.GuildInstall, ApplicationIntegrationType.UserInstall],
             options: {
                 color: SlashCommandOptionBuilder.string({
                     description: "The color to show information about.",

--- a/apps/barry/src/modules/general/commands/chatinput/config/index.ts
+++ b/apps/barry/src/modules/general/commands/chatinput/config/index.ts
@@ -2,6 +2,7 @@ import {
     type APIEmbedFooter,
     type APISelectMenuOption,
     ComponentType,
+    InteractionContextType,
     MessageFlags,
     PermissionFlagsBits
 } from "@discordjs/core";
@@ -51,8 +52,8 @@ export default class extends SlashCommand<GeneralModule> {
         super(module, {
             name: "config",
             description: "Manage the configuration of the bot for this server.",
-            defaultMemberPermissions: PermissionFlagsBits.ManageGuild,
-            guildOnly: true
+            contexts: [InteractionContextType.Guild],
+            defaultMemberPermissions: PermissionFlagsBits.ManageGuild
         });
     }
 

--- a/apps/barry/src/modules/general/commands/chatinput/contrast/index.ts
+++ b/apps/barry/src/modules/general/commands/chatinput/contrast/index.ts
@@ -5,9 +5,9 @@ import {
 } from "@barry-bot/core";
 import type GeneralModule from "../../../index.js";
 
+import { ApplicationIntegrationType, MessageFlags } from "@discordjs/core";
 import { Canvas, loadFont } from "canvas-constructor/napi-rs";
 import { getContrastScore, parseColor } from "../../../functions/colors.js";
-import { MessageFlags } from "@discordjs/core";
 import { join } from "node:path";
 import config from "../../../../../config.js";
 
@@ -52,6 +52,7 @@ export default class extends SlashCommand<GeneralModule> {
         super(module, {
             name: "contrast",
             description: "Check the contrast between two colors.",
+            integrationTypes: [ApplicationIntegrationType.GuildInstall, ApplicationIntegrationType.UserInstall],
             options: {
                 background: SlashCommandOptionBuilder.string({
                     description: "The background color.",

--- a/apps/barry/src/modules/general/commands/chatinput/convert/currency/index.ts
+++ b/apps/barry/src/modules/general/commands/chatinput/convert/currency/index.ts
@@ -1,5 +1,13 @@
-import { type APIApplicationCommandOptionChoice, MessageFlags } from "@discordjs/core";
-import { type ApplicationCommandInteraction, SlashCommand, SlashCommandOptionBuilder } from "@barry-bot/core";
+import {
+    type APIApplicationCommandOptionChoice,
+    ApplicationIntegrationType,
+    MessageFlags
+} from "@discordjs/core";
+import {
+    type ApplicationCommandInteraction,
+    SlashCommand,
+    SlashCommandOptionBuilder
+} from "@barry-bot/core";
 import type GeneralModule from "../../../../index.js";
 
 import { fetch } from "undici";
@@ -137,6 +145,7 @@ export default class extends SlashCommand<GeneralModule> {
         super(module, {
             name: "currency",
             description: "Converts currency from one to another.",
+            integrationTypes: [ApplicationIntegrationType.GuildInstall, ApplicationIntegrationType.UserInstall],
             options: {
                 amount: SlashCommandOptionBuilder.number({
                     description: "The amount to convert.",

--- a/apps/barry/src/modules/general/commands/chatinput/convert/index.ts
+++ b/apps/barry/src/modules/general/commands/chatinput/convert/index.ts
@@ -1,5 +1,6 @@
 import type GeneralModule from "../../../index.js";
 
+import { ApplicationIntegrationType } from "@discordjs/core";
 import { SlashCommand } from "@barry-bot/core";
 import ConvertCurrencyCommand from "./currency/index.js";
 import ConvertUnitCommand from "./unit/index.js";
@@ -17,6 +18,7 @@ export default class extends SlashCommand<GeneralModule> {
         super(module, {
             name: "convert",
             description: "Converts one unit to another.",
+            integrationTypes: [ApplicationIntegrationType.GuildInstall, ApplicationIntegrationType.UserInstall],
             children: [
                 ConvertCurrencyCommand,
                 ConvertUnitCommand

--- a/apps/barry/src/modules/general/commands/chatinput/convert/unit/index.ts
+++ b/apps/barry/src/modules/general/commands/chatinput/convert/unit/index.ts
@@ -1,4 +1,8 @@
-import { type APIApplicationCommandOptionChoice, MessageFlags } from "@discordjs/core";
+import {
+    type APIApplicationCommandOptionChoice,
+    ApplicationIntegrationType,
+    MessageFlags
+} from "@discordjs/core";
 import {
     type ApplicationCommandInteraction,
     type AutocompleteInteraction,
@@ -63,6 +67,7 @@ export default class extends SlashCommand<GeneralModule> {
         super(module, {
             name: "unit",
             description: "Converts one unit to another.",
+            integrationTypes: [ApplicationIntegrationType.GuildInstall, ApplicationIntegrationType.UserInstall],
             options: {
                 amount: SlashCommandOptionBuilder.number({
                     description: "The amount to convert.",

--- a/apps/barry/src/modules/general/commands/chatinput/lipsum/index.ts
+++ b/apps/barry/src/modules/general/commands/chatinput/lipsum/index.ts
@@ -5,6 +5,7 @@ import {
 } from "@barry-bot/core";
 import type GeneralModule from "../../../index.js";
 
+import { ApplicationIntegrationType } from "@discordjs/core";
 import {
     generateParagraphs,
     generateSentences,
@@ -45,6 +46,7 @@ export default class extends SlashCommand<GeneralModule> {
         super(module, {
             name: "lipsum",
             description: "Lorem ipsum dolor sit amet.",
+            integrationTypes: [ApplicationIntegrationType.GuildInstall, ApplicationIntegrationType.UserInstall],
             options: {
                 words: SlashCommandOptionBuilder.integer({
                     description: "The amount of words to generate.",

--- a/apps/barry/src/modules/general/commands/chatinput/ping/index.ts
+++ b/apps/barry/src/modules/general/commands/chatinput/ping/index.ts
@@ -3,8 +3,9 @@ import {
     SlashCommand,
     getCreatedAt
 } from "@barry-bot/core";
-
 import type GeneralModule from "../../../index.js";
+
+import { ApplicationIntegrationType } from "@discordjs/core";
 import config from "../../../../../config.js";
 
 /**
@@ -19,7 +20,8 @@ export default class extends SlashCommand<GeneralModule> {
     constructor(module: GeneralModule) {
         super(module, {
             name: "ping",
-            description: "Shows the latency of the bot."
+            description: "Shows the latency of the bot.",
+            integrationTypes: [ApplicationIntegrationType.GuildInstall, ApplicationIntegrationType.UserInstall]
         });
     }
 

--- a/apps/barry/src/modules/general/commands/chatinput/reverse/image/index.ts
+++ b/apps/barry/src/modules/general/commands/chatinput/reverse/image/index.ts
@@ -3,7 +3,11 @@ import {
     SlashCommand,
     SlashCommandOptionBuilder
 } from "@barry-bot/core";
-import { type APIAttachment, MessageFlags } from "@discordjs/core";
+import {
+    type APIAttachment,
+    ApplicationIntegrationType,
+    MessageFlags
+} from "@discordjs/core";
 import type GeneralModule from "../../../../index.js";
 
 import { getReverseContent } from "../../../../functions/reverse/getReverseContent.js";
@@ -22,6 +26,7 @@ export default class extends SlashCommand<GeneralModule> {
         super(module, {
             name: "image",
             description: "Reverse search an image.",
+            integrationTypes: [ApplicationIntegrationType.GuildInstall, ApplicationIntegrationType.UserInstall],
             options: {
                 image: SlashCommandOptionBuilder.attachments({
                     description: "The image to reverse search.",

--- a/apps/barry/src/modules/general/commands/chatinput/reverse/index.ts
+++ b/apps/barry/src/modules/general/commands/chatinput/reverse/index.ts
@@ -1,5 +1,6 @@
 import type GeneralModule from "../../../index.js";
 
+import { ApplicationIntegrationType } from "@discordjs/core";
 import { SlashCommand } from "@barry-bot/core";
 import ReverseImageCommand from "./image/index.js";
 
@@ -16,7 +17,8 @@ export default class extends SlashCommand<GeneralModule> {
         super(module, {
             name: "reverse",
             description: "Reverse search an image.",
-            children: [ReverseImageCommand]
+            children: [ReverseImageCommand],
+            integrationTypes: [ApplicationIntegrationType.GuildInstall, ApplicationIntegrationType.UserInstall]
         });
     }
 

--- a/apps/barry/src/modules/general/commands/message/reverse/index.ts
+++ b/apps/barry/src/modules/general/commands/message/reverse/index.ts
@@ -6,7 +6,7 @@ import {
 
 import type GeneralModule from "../../../index.js";
 
-import { MessageFlags } from "@discordjs/core";
+import { ApplicationIntegrationType, MessageFlags } from "@discordjs/core";
 import { PaginationMessage } from "../../../../../utils/pagination.js";
 import { getReverseContent } from "../../../functions/reverse/getReverseContent.js";
 
@@ -23,7 +23,8 @@ export default class extends MessageCommand<GeneralModule> {
      */
     constructor(module: GeneralModule) {
         super(module, {
-            name: "Reverse Search Image"
+            name: "Reverse Search Image",
+            integrationTypes: [ApplicationIntegrationType.GuildInstall, ApplicationIntegrationType.UserInstall]
         });
     }
 

--- a/apps/barry/src/modules/general/commands/user/avatar/index.ts
+++ b/apps/barry/src/modules/general/commands/user/avatar/index.ts
@@ -4,8 +4,9 @@ import {
     UserCommand,
     getDefaultAvatarURL
 } from "@barry-bot/core";
-
 import type GeneralModule from "../../../index.js";
+
+import { ApplicationIntegrationType } from "@discordjs/core";
 import config from "../../../../../config.js";
 
 /**
@@ -19,7 +20,8 @@ export default class extends UserCommand<GeneralModule> {
      */
     constructor(module: GeneralModule) {
         super(module, {
-            name: "View Avatar"
+            name: "View Avatar",
+            integrationTypes: [ApplicationIntegrationType.GuildInstall, ApplicationIntegrationType.UserInstall]
         });
     }
 

--- a/apps/barry/src/modules/general/commands/user/reverse/index.ts
+++ b/apps/barry/src/modules/general/commands/user/reverse/index.ts
@@ -6,7 +6,7 @@ import {
 
 import type GeneralModule from "../../../index.js";
 
-import { MessageFlags } from "@discordjs/core";
+import { ApplicationIntegrationType, MessageFlags } from "@discordjs/core";
 import { getReverseAvatarContent } from "../../../functions/reverse/getReverseContent.js";
 
 import config from "../../../../../config.js";
@@ -22,7 +22,8 @@ export default class extends UserCommand<GeneralModule> {
      */
     constructor(module: GeneralModule) {
         super(module, {
-            name: "Reverse Search Avatar"
+            name: "Reverse Search Avatar",
+            integrationTypes: [ApplicationIntegrationType.GuildInstall, ApplicationIntegrationType.UserInstall]
         });
     }
 

--- a/apps/barry/src/modules/leveling/commands/chatinput/leaderboard/index.ts
+++ b/apps/barry/src/modules/leveling/commands/chatinput/leaderboard/index.ts
@@ -2,6 +2,7 @@ import {
     type APIButtonComponentWithCustomId,
     ButtonStyle,
     ComponentType,
+    InteractionContextType,
     MessageFlags,
     TextInputStyle
 } from "@discordjs/core";
@@ -69,7 +70,7 @@ export default class extends SlashCommand<LevelingModule> {
         super(module, {
             name: "leaderboard",
             description: "View the most active members of this server.",
-            guildOnly: true
+            contexts: [InteractionContextType.Guild]
         });
     }
 

--- a/apps/barry/src/modules/leveling/commands/chatinput/rank/index.ts
+++ b/apps/barry/src/modules/leveling/commands/chatinput/rank/index.ts
@@ -6,6 +6,7 @@ import {
 } from "@barry-bot/core";
 import type LevelingModule from "../../../index.js";
 
+import { InteractionContextType } from "@discordjs/core";
 import { viewRank } from "../../../functions/viewRank.js";
 
 /**
@@ -21,7 +22,7 @@ export default class extends SlashCommand<LevelingModule> {
         super(module, {
             name: "rank",
             description: "View someone's rank card.",
-            guildOnly: true,
+            contexts: [InteractionContextType.Guild],
             options: {
                 user: SlashCommandOptionBuilder.user({
                     description: "The user to view the rank card of.",

--- a/apps/barry/src/modules/leveling/commands/user/rank/index.ts
+++ b/apps/barry/src/modules/leveling/commands/user/rank/index.ts
@@ -5,6 +5,7 @@ import {
 } from "@barry-bot/core";
 import type LevelingModule from "../../../index.js";
 
+import { InteractionContextType } from "@discordjs/core";
 import { viewRank } from "../../../functions/viewRank.js";
 
 /**
@@ -19,7 +20,7 @@ export default class extends UserCommand<LevelingModule> {
     constructor(module: LevelingModule) {
         super(module, {
             name: "View Rank",
-            guildOnly: true
+            contexts: [InteractionContextType.Guild]
         });
     }
 

--- a/apps/barry/src/modules/leveling/commands/user/rep/index.ts
+++ b/apps/barry/src/modules/leveling/commands/user/rep/index.ts
@@ -5,7 +5,7 @@ import {
 } from "@barry-bot/core";
 import type LevelingModule from "../../../index.js";
 
-import { MessageFlags } from "@discordjs/core";
+import { InteractionContextType, MessageFlags } from "@discordjs/core";
 import config from "../../../../../config.js";
 
 /**
@@ -20,8 +20,8 @@ export default class extends UserCommand<LevelingModule> {
     constructor(module: LevelingModule) {
         super(module, {
             name: "Give Reputation",
-            cooldown: 86400,
-            guildOnly: true
+            contexts: [InteractionContextType.Guild],
+            cooldown: 86400
         });
     }
 

--- a/apps/barry/src/modules/moderation/commands/chatinput/ban/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/ban/index.ts
@@ -6,8 +6,8 @@ import {
 import type { BanOptions } from "../../../../../types/moderation.js";
 import type ModerationModule from "../../../index.js";
 
+import { InteractionContextType, PermissionFlagsBits } from "@discordjs/core";
 import { COMMON_SEVERE_REASONS } from "../../../constants.js";
-import { PermissionFlagsBits } from "@discordjs/core";
 
 /**
  * Represents a slash command that bans a user.
@@ -23,8 +23,8 @@ export default class extends SlashCommand<ModerationModule> {
             name: "ban",
             description: "Ban a user from the server.",
             appPermissions: PermissionFlagsBits.BanMembers,
+            contexts: [InteractionContextType.Guild],
             defaultMemberPermissions: PermissionFlagsBits.BanMembers,
-            guildOnly: true,
             options: {
                 user: SlashCommandOptionBuilder.user({
                     description: "The user to ban.",

--- a/apps/barry/src/modules/moderation/commands/chatinput/cases/delete/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/cases/delete/index.ts
@@ -8,6 +8,7 @@ import type ModerationModule from "../../../../index.js";
 import {
     ButtonStyle,
     ComponentType,
+    InteractionContextType,
     MessageFlags,
     PermissionFlagsBits
 } from "@discordjs/core";
@@ -37,8 +38,8 @@ export default class extends SlashCommand<ModerationModule> {
         super(module, {
             name: "delete",
             description: "Delete a specific case.",
+            contexts: [InteractionContextType.Guild],
             defaultMemberPermissions: PermissionFlagsBits.ModerateMembers,
-            guildOnly: true,
             options: {
                 case: SlashCommandOptionBuilder.integer({
                     description: "The ID of the case to delete.",

--- a/apps/barry/src/modules/moderation/commands/chatinput/cases/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/cases/index.ts
@@ -1,5 +1,6 @@
 import type ModerationModule from "../../../index.js";
 
+import { InteractionContextType } from "@discordjs/core";
 import { SlashCommand } from "@barry-bot/core";
 import DeleteCommand from "./delete/index.js";
 import NoteCommand from "./notes/index.js";
@@ -18,7 +19,7 @@ export default class extends SlashCommand<ModerationModule> {
         super(module, {
             name: "cases",
             description: "Manage or view a case.",
-            guildOnly: true,
+            contexts: [InteractionContextType.Guild],
             children: [
                 DeleteCommand,
                 NoteCommand,

--- a/apps/barry/src/modules/moderation/commands/chatinput/cases/notes/add/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/cases/notes/add/index.ts
@@ -5,7 +5,11 @@ import {
 } from "@barry-bot/core";
 import type ModerationModule from "../../../../../index.js";
 
-import { MessageFlags, PermissionFlagsBits } from "@discordjs/core";
+import {
+    InteractionContextType,
+    MessageFlags,
+    PermissionFlagsBits
+} from "@discordjs/core";
 import config from "../../../../../../../config.js";
 
 /**
@@ -36,8 +40,8 @@ export default class extends SlashCommand<ModerationModule> {
         super(module, {
             name: "add",
             description: "Adds a note to a case.",
+            contexts: [InteractionContextType.Guild],
             defaultMemberPermissions: PermissionFlagsBits.ModerateMembers,
-            guildOnly: true,
             options: {
                 case: SlashCommandOptionBuilder.integer({
                     description: "The ID of the case.",

--- a/apps/barry/src/modules/moderation/commands/chatinput/cases/notes/delete/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/cases/notes/delete/index.ts
@@ -5,7 +5,11 @@ import {
 } from "@barry-bot/core";
 import type ModerationModule from "../../../../../index.js";
 
-import { MessageFlags, PermissionFlagsBits } from "@discordjs/core";
+import {
+    InteractionContextType,
+    MessageFlags,
+    PermissionFlagsBits
+} from "@discordjs/core";
 import config from "../../../../../../../config.js";
 
 /**
@@ -41,8 +45,8 @@ export default class extends SlashCommand<ModerationModule> {
         super(module, {
             name: "delete",
             description: "Removes a note from a case.",
+            contexts: [InteractionContextType.Guild],
             defaultMemberPermissions: PermissionFlagsBits.ModerateMembers,
-            guildOnly: true,
             options: {
                 case: SlashCommandOptionBuilder.integer({
                     description: "The ID of the case.",

--- a/apps/barry/src/modules/moderation/commands/chatinput/cases/notes/edit/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/cases/notes/edit/index.ts
@@ -5,7 +5,11 @@ import {
 } from "@barry-bot/core";
 import type ModerationModule from "../../../../../index.js";
 
-import { MessageFlags, PermissionFlagsBits } from "@discordjs/core";
+import {
+    InteractionContextType,
+    MessageFlags,
+    PermissionFlagsBits
+} from "@discordjs/core";
 import config from "../../../../../../../config.js";
 
 /**
@@ -41,8 +45,8 @@ export default class extends SlashCommand<ModerationModule> {
         super(module, {
             name: "edit",
             description: "Edits the content of a note.",
+            contexts: [InteractionContextType.Guild],
             defaultMemberPermissions: PermissionFlagsBits.ModerateMembers,
-            guildOnly: true,
             options: {
                 case: SlashCommandOptionBuilder.integer({
                     description: "The ID of the case.",

--- a/apps/barry/src/modules/moderation/commands/chatinput/cases/notes/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/cases/notes/index.ts
@@ -1,6 +1,6 @@
 import type ModerationModule from "../../../../index.js";
 
-import { PermissionFlagsBits } from "@discordjs/core";
+import { InteractionContextType, PermissionFlagsBits } from "@discordjs/core";
 import { SlashCommand } from "@barry-bot/core";
 import AddNoteCommand from "./add/index.js";
 import DeleteNoteCommand from "./delete/index.js";
@@ -19,8 +19,8 @@ export default class extends SlashCommand<ModerationModule> {
         super(module, {
             name: "notes",
             description: "Modify or add notes to a case.",
+            contexts: [InteractionContextType.Guild],
             defaultMemberPermissions: PermissionFlagsBits.ModerateMembers,
-            guildOnly: true,
             children: [
                 AddNoteCommand,
                 DeleteNoteCommand,

--- a/apps/barry/src/modules/moderation/commands/chatinput/cases/view/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/cases/view/index.ts
@@ -1,6 +1,7 @@
 import {
     type APIGuild,
     type APIUser,
+    InteractionContextType,
     MessageFlags,
     PermissionFlagsBits
 } from "@discordjs/core";
@@ -62,8 +63,8 @@ export default class extends SlashCommand<ModerationModule> {
         super(module, {
             name: "view",
             description: "View specific or all cases.",
+            contexts: [InteractionContextType.Guild],
             defaultMemberPermissions: PermissionFlagsBits.ModerateMembers,
-            guildOnly: true,
             options: {
                 case: SlashCommandOptionBuilder.integer({
                     description: "The ID of the case to view.",

--- a/apps/barry/src/modules/moderation/commands/chatinput/dwc/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/dwc/index.ts
@@ -6,8 +6,8 @@ import {
 import { type DWCOptions } from "../../../../../types/moderation.js";
 import type ModerationModule from "../../../index.js";
 
+import { InteractionContextType, PermissionFlagsBits } from "@discordjs/core";
 import { COMMON_DWC_REASONS } from "../../../constants.js";
-import { PermissionFlagsBits } from "@discordjs/core";
 
 /**
  * Represents a slash command to mark a user as 'Deal with Caution'.
@@ -23,8 +23,8 @@ export default class extends SlashCommand<ModerationModule> {
             name: "dwc",
             description: "Marks a user as 'Deal With Caution' and bans them after a week.",
             appPermissions: PermissionFlagsBits.BanMembers | PermissionFlagsBits.ManageRoles,
+            contexts: [InteractionContextType.Guild],
             defaultMemberPermissions: PermissionFlagsBits.BanMembers,
-            guildOnly: true,
             options: {
                 user: SlashCommandOptionBuilder.user({
                     description: "The user to mark as 'Deal With Caution'.",

--- a/apps/barry/src/modules/moderation/commands/chatinput/kick/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/kick/index.ts
@@ -6,8 +6,8 @@ import {
 import { type KickOptions } from "../../../../../types/moderation.js";
 import type ModerationModule from "../../../index.js";
 
+import { InteractionContextType, PermissionFlagsBits } from "@discordjs/core";
 import { COMMON_SEVERE_REASONS } from "../../../constants.js";
-import { PermissionFlagsBits } from "@discordjs/core";
 
 /**
  * Represents a slash command that kicks a user.
@@ -23,8 +23,8 @@ export default class extends SlashCommand<ModerationModule> {
             name: "kick",
             description: "Kick a user from the server.",
             appPermissions: PermissionFlagsBits.KickMembers,
+            contexts: [InteractionContextType.Guild],
             defaultMemberPermissions: PermissionFlagsBits.KickMembers,
-            guildOnly: true,
             options: {
                 member: SlashCommandOptionBuilder.member({
                     description: "The member to kick.",

--- a/apps/barry/src/modules/moderation/commands/chatinput/mute/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/mute/index.ts
@@ -6,8 +6,8 @@ import {
 import { type MuteOptions } from "../../../../../types/moderation.js";
 import type ModerationModule from "../../../index.js";
 
+import { InteractionContextType, PermissionFlagsBits } from "@discordjs/core";
 import { COMMON_MINOR_REASONS } from "../../../constants.js";
-import { PermissionFlagsBits } from "@discordjs/core";
 
 /**
  * Represents a slash command that times out a user.
@@ -23,8 +23,8 @@ export default class extends SlashCommand<ModerationModule> {
             name: "mute",
             description: "Mute a member.",
             appPermissions: PermissionFlagsBits.ModerateMembers,
+            contexts: [InteractionContextType.Guild],
             defaultMemberPermissions: PermissionFlagsBits.ModerateMembers,
-            guildOnly: true,
             options: {
                 member: SlashCommandOptionBuilder.member({
                     description: "The member to mute.",

--- a/apps/barry/src/modules/moderation/commands/chatinput/note/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/note/index.ts
@@ -1,5 +1,6 @@
 import {
     type APIUser,
+    InteractionContextType,
     MessageFlags,
     PermissionFlagsBits
 } from "@discordjs/core";
@@ -41,8 +42,8 @@ export default class extends SlashCommand<ModerationModule> {
         super(module, {
             name: "note",
             description: "Adds a note to a user.",
+            contexts: [InteractionContextType.Guild],
             defaultMemberPermissions: PermissionFlagsBits.ModerateMembers,
-            guildOnly: true,
             options: {
                 user: SlashCommandOptionBuilder.user({
                     description: "The user to add a note to.",

--- a/apps/barry/src/modules/moderation/commands/chatinput/purge/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/purge/index.ts
@@ -1,6 +1,7 @@
 import {
     type APIMessage,
     type APIUser,
+    InteractionContextType,
     MessageFlags,
     PermissionFlagsBits
 } from "@discordjs/core";
@@ -48,8 +49,8 @@ export default class extends SlashCommand<ModerationModule> {
             name: "purge",
             description: "Purge messages from the current channel.",
             appPermissions: PermissionFlagsBits.ManageMessages,
+            contexts: [InteractionContextType.Guild],
             defaultMemberPermissions: PermissionFlagsBits.ManageMessages,
-            guildOnly: true,
             options: {
                 amount: SlashCommandOptionBuilder.integer({
                     description: "The amount of messages to purge.",

--- a/apps/barry/src/modules/moderation/commands/chatinput/unban/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/unban/index.ts
@@ -1,5 +1,6 @@
 import {
     type APIUser,
+    InteractionContextType,
     MessageFlags,
     PermissionFlagsBits
 } from "@discordjs/core";
@@ -43,8 +44,8 @@ export default class extends SlashCommand<ModerationModule> {
             name: "unban",
             description: "Unban a user.",
             appPermissions: PermissionFlagsBits.BanMembers,
+            contexts: [InteractionContextType.Guild],
             defaultMemberPermissions: PermissionFlagsBits.BanMembers,
-            guildOnly: true,
             options: {
                 user: SlashCommandOptionBuilder.user({
                     description: "The user to unban.",

--- a/apps/barry/src/modules/moderation/commands/chatinput/undwc/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/undwc/index.ts
@@ -1,5 +1,6 @@
 import {
     type APIUser,
+    InteractionContextType,
     MessageFlags,
     PermissionFlagsBits
 } from "@discordjs/core";
@@ -45,8 +46,8 @@ export default class extends SlashCommand<ModerationModule> {
             name: "undwc",
             description: "Removes the 'Deal With Caution' flag from a user.",
             appPermissions: PermissionFlagsBits.ManageRoles,
+            contexts: [InteractionContextType.Guild],
             defaultMemberPermissions: PermissionFlagsBits.BanMembers,
-            guildOnly: true,
             options: {
                 user: SlashCommandOptionBuilder.user({
                     description: "The user to remove the flag of.",

--- a/apps/barry/src/modules/moderation/commands/chatinput/unmute/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/unmute/index.ts
@@ -6,7 +6,11 @@ import {
 import type { PartialGuildMember } from "../../../functions/permissions.js";
 import type ModerationModule from "../../../index.js";
 
-import { MessageFlags, PermissionFlagsBits } from "@discordjs/core";
+import {
+    InteractionContextType,
+    MessageFlags,
+    PermissionFlagsBits
+} from "@discordjs/core";
 import { CaseType } from "@prisma/client";
 import config from "../../../../../config.js";
 
@@ -39,8 +43,8 @@ export default class extends SlashCommand<ModerationModule> {
             name: "unmute",
             description: "Unmute a member.",
             appPermissions: PermissionFlagsBits.ModerateMembers,
+            contexts: [InteractionContextType.Guild],
             defaultMemberPermissions: PermissionFlagsBits.ModerateMembers,
-            guildOnly: true,
             options: {
                 member: SlashCommandOptionBuilder.member({
                     description: "The member to unmute.",

--- a/apps/barry/src/modules/moderation/commands/chatinput/warn/index.ts
+++ b/apps/barry/src/modules/moderation/commands/chatinput/warn/index.ts
@@ -6,8 +6,8 @@ import {
 import { type WarnOptions } from "../../../../../types/moderation.js";
 import type ModerationModule from "../../../index.js";
 
+import { InteractionContextType, PermissionFlagsBits } from "@discordjs/core";
 import { COMMON_MINOR_REASONS } from "../../../constants.js";
-import { PermissionFlagsBits } from "@discordjs/core";
 
 /**
  * Represents a slash command that warns a user.
@@ -22,8 +22,8 @@ export default class extends SlashCommand<ModerationModule> {
         super(module, {
             name: "warn",
             description: "Warns a user.",
+            contexts: [InteractionContextType.Guild],
             defaultMemberPermissions: PermissionFlagsBits.ModerateMembers,
-            guildOnly: true,
             options: {
                 member: SlashCommandOptionBuilder.member({
                     description: "The member to warn.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,9 +36,9 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@barry-bot/core": "*",
-        "@discordjs/core": "^1.1.1",
-        "@discordjs/rest": "^2.2.0",
-        "@discordjs/ws": "^1.0.2",
+        "@discordjs/core": "^1.3.0-dev.1721153953-efa16a609",
+        "@discordjs/rest": "^2.4.0-dev.1721153952-efa16a609",
+        "@discordjs/ws": "^1.2.0-dev.1721153959-efa16a609",
         "@napi-rs/canvas": "^0.1.41",
         "@prisma/client": "^5.0.0",
         "canvas-constructor": "^7.0.1",
@@ -56,6 +56,95 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "apps/barry/node_modules/@discordjs/rest": {
+      "version": "2.4.0-dev.1721153952-efa16a609",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.4.0-dev.1721153952-efa16a609.tgz",
+      "integrity": "sha512-Nr7d5+4YXDALkNWESTF3ejizU+lVYyzIdMiu2I4+bNdhXozZzp/gZp8/Dk3O+LGRlDLO0foFJRk70UaMwjXmrQ==",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "0.37.90",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.2",
+        "undici": "6.18.2"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "apps/barry/node_modules/@discordjs/rest/node_modules/undici": {
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.18.2.tgz",
+      "integrity": "sha512-o/MQLTwRm9IVhOqhZ0NQ9oXax1ygPjw6Vs+Vq/4QRjbOAC3B1GCHy7TYxxbExKlb7bzDRzt9vBWU6BDz0RFfYg==",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "apps/barry/node_modules/@discordjs/ws": {
+      "version": "1.2.0-dev.1721153959-efa16a609",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.0-dev.1721153959-efa16a609.tgz",
+      "integrity": "sha512-Vo6HhS7R9F2jJV2rykLsloQPJKdiPR/PpHslFy192EgkOByiwC3JhL7+wzL6ATNitl6lsDTzQLwsPpMj1crbDA==",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.3.0",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "0.37.90",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "apps/barry/node_modules/@discordjs/ws/node_modules/@discordjs/rest": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.3.0.tgz",
+      "integrity": "sha512-C1kAJK8aSYRv3ZwMG8cvrrW4GN0g5eMdP8AuN8ODH5DyOCbHgJspze1my3xHOAgwLJdKUbWNVyAeJ9cEdduqIg==",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "0.37.83",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.2",
+        "undici": "6.13.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "apps/barry/node_modules/@discordjs/ws/node_modules/@discordjs/rest/node_modules/discord-api-types": {
+      "version": "0.37.83",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.83.tgz",
+      "integrity": "sha512-urGGYeWtWNYMKnYlZnOnDHm8fVRffQs3U0SpE8RHeiuLKb/u92APS8HoQnPTFbnXmY1vVnXjXO4dOxcAn3J+DA=="
+    },
+    "apps/barry/node_modules/discord-api-types": {
+      "version": "0.37.90",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.90.tgz",
+      "integrity": "sha512-lpOJSGrqHuXoM4FV/2HtjoaJpCClGFHpRNIdZEW8zPINlsCHNSfIwA2EQ8dxeE6k1QhhTuM9ZlOGVYXoU7FLgA=="
+    },
+    "apps/barry/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
@@ -98,46 +187,60 @@
       "dev": true
     },
     "node_modules/@discordjs/collection": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.0.0.tgz",
-      "integrity": "sha512-YTWIXLrf5FsrLMycpMM9Q6vnZoR/lN2AWX23/Cuo8uOOtS8eHB2dyQaaGnaF8aZPYnttf2bkLMcXn/j6JUOi3w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.0.tgz",
+      "integrity": "sha512-mLcTACtXUuVgutoznkh6hS3UFqYirDYAg5Dc1m8xn6OvPjetnUlf/xjtqnnc47OwWdaoCQnHmHh9KofhD6uRqw==",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/core/-/core-1.1.1.tgz",
-      "integrity": "sha512-3tDqc6KCAtE0CxNl5300uPzFnNsY/GAmJhc6oGutbl/la+4mRv5zVb4N68cmcaeD2Il/ySH4zIc00sq+cyhtUA==",
+      "version": "1.3.0-dev.1721153953-efa16a609",
+      "resolved": "https://registry.npmjs.org/@discordjs/core/-/core-1.3.0-dev.1721153953-efa16a609.tgz",
+      "integrity": "sha512-BUbuXjxfEYqw32TcsBDblpYbcm8ohB8G3H5BFtWFtKCqcwQVny4WE6+rmaMzb202a3aZ89PZeeOU1BPBlz0p3Q==",
       "dependencies": {
-        "@discordjs/rest": "^2.2.0",
-        "@discordjs/util": "^1.0.2",
-        "@discordjs/ws": "^1.0.2",
-        "@sapphire/snowflake": "^3.5.1",
-        "@vladfrangu/async_event_emitter": "^2.2.2",
-        "discord-api-types": "0.37.61"
+        "@discordjs/rest": "^2.3.0",
+        "@discordjs/util": "^1.1.0",
+        "@discordjs/ws": "^1.1.1",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "0.37.90"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
+    "node_modules/@discordjs/core/node_modules/discord-api-types": {
+      "version": "0.37.90",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.90.tgz",
+      "integrity": "sha512-lpOJSGrqHuXoM4FV/2HtjoaJpCClGFHpRNIdZEW8zPINlsCHNSfIwA2EQ8dxeE6k1QhhTuM9ZlOGVYXoU7FLgA=="
+    },
     "node_modules/@discordjs/rest": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.2.0.tgz",
-      "integrity": "sha512-nXm9wT8oqrYFRMEqTXQx9DUTeEtXUDMmnUKIhZn6O2EeDY9VCdwj23XCPq7fkqMPKdF7ldAfeVKyxxFdbZl59A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.3.0.tgz",
+      "integrity": "sha512-C1kAJK8aSYRv3ZwMG8cvrrW4GN0g5eMdP8AuN8ODH5DyOCbHgJspze1my3xHOAgwLJdKUbWNVyAeJ9cEdduqIg==",
       "dependencies": {
-        "@discordjs/collection": "^2.0.0",
-        "@discordjs/util": "^1.0.2",
-        "@sapphire/async-queue": "^1.5.0",
-        "@sapphire/snowflake": "^3.5.1",
-        "@vladfrangu/async_event_emitter": "^2.2.2",
-        "discord-api-types": "0.37.61",
-        "magic-bytes.js": "^1.5.0",
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "0.37.83",
+        "magic-bytes.js": "^1.10.0",
         "tslib": "^2.6.2",
-        "undici": "5.27.2"
+        "undici": "6.13.0"
       },
       "engines": {
         "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/rest/node_modules/tslib": {
@@ -146,30 +249,36 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@discordjs/util": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.0.2.tgz",
-      "integrity": "sha512-IRNbimrmfb75GMNEjyznqM1tkI7HrZOf14njX7tCAAUetyZM1Pr8hX/EK2lxBCOgWDRmigbp24fD1hdMfQK5lw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.0.tgz",
+      "integrity": "sha512-IndcI5hzlNZ7GS96RV3Xw1R2kaDuXEp7tRIy/KlhidpN/BQ1qh1NZt3377dMLTa44xDUNKT7hnXkA/oUAzD/lg==",
       "engines": {
         "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/ws": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.0.2.tgz",
-      "integrity": "sha512-+XI82Rm2hKnFwAySXEep4A7Kfoowt6weO6381jgW+wVdTpMS/56qCvoXyFRY0slcv7c/U8My2PwIB2/wEaAh7Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.1.1.tgz",
+      "integrity": "sha512-PZ+vLpxGCRtmr2RMkqh8Zp+BenUaJqlS6xhgWKEZcgC/vfHLEzpHtKkB0sl3nZWpwtcKk6YWy+pU3okL2I97FA==",
       "dependencies": {
-        "@discordjs/collection": "^2.0.0",
-        "@discordjs/rest": "^2.1.0",
-        "@discordjs/util": "^1.0.2",
-        "@sapphire/async-queue": "^1.5.0",
-        "@types/ws": "^8.5.9",
-        "@vladfrangu/async_event_emitter": "^2.2.2",
-        "discord-api-types": "0.37.61",
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.3.0",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "0.37.83",
         "tslib": "^2.6.2",
-        "ws": "^8.14.2"
+        "ws": "^8.16.0"
       },
       "engines": {
         "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/ws/node_modules/tslib": {
@@ -614,14 +723,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
-      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
-      "engines": {
-        "node": ">=14"
-      }
     },
     "node_modules/@fastify/deepmerge": {
       "version": "1.3.0",
@@ -1184,18 +1285,18 @@
       ]
     },
     "node_modules/@sapphire/async-queue": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
-      "integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.2.tgz",
+      "integrity": "sha512-7X7FFAA4DngXUl95+hYbUF19bp1LGiffjJtu7ygrZrbdCSsdDDBaSjB7Akw0ZbOu6k0xpXyljnJ6/RZUvLfRdg==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@sapphire/snowflake": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.1.tgz",
-      "integrity": "sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -1651,9 +1752,9 @@
       }
     },
     "node_modules/@vladfrangu/async_event_emitter": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.2.tgz",
-      "integrity": "sha512-HIzRG7sy88UZjBJamssEczH5q7t5+axva19UbZLO6u0ySbYPrwzWiXBcC0WuHyhKKoeCyneH+FvYzKQq/zTtkQ==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.4.tgz",
+      "integrity": "sha512-ZL62PFXEIeGUI8btfJ5S8Flc286eU1ZUSjwyFQtIGXfRUDPZKO+CDJMYb1R71LjGWRZ4n202O+a6FGjsgTw58g==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -2215,9 +2316,9 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.37.61",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.61.tgz",
-      "integrity": "sha512-o/dXNFfhBpYHpQFdT6FWzeO7pKc838QeeZ9d91CfVAtpr5XLK4B/zYxQbYgPdoMiTDvJfzcsLW5naXgmHGDNXw=="
+      "version": "0.37.83",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.83.tgz",
+      "integrity": "sha512-urGGYeWtWNYMKnYlZnOnDHm8fVRffQs3U0SpE8RHeiuLKb/u92APS8HoQnPTFbnXmY1vVnXjXO4dOxcAn3J+DA=="
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -3586,9 +3687,9 @@
       }
     },
     "node_modules/magic-bytes.js": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.5.0.tgz",
-      "integrity": "sha512-wJkXvutRbNWcc37tt5j1HyOK1nosspdh3dj6LUYYAvF6JYNqs53IfRvK9oEpcwiDA1NdoIi64yAMfdivPeVAyw=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.10.0.tgz",
+      "integrity": "sha512-/k20Lg2q8LE5xiaaSkMXk4sfvI+9EGEykFS4b0CHHGWqDYU0bGUFSwchNOMA56D7TCs9GwVTkqe9als1/ns8UQ=="
     },
     "node_modules/magic-string": {
       "version": "0.30.5",
@@ -5076,14 +5177,11 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "5.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.27.2.tgz",
-      "integrity": "sha512-iS857PdOEy/y3wlM3yRp+6SNQQ6xU0mmZcwRSriqk+et/cwWAtwmIGf6WkoDN2EK/AMdCO/dfXzIwi+rFMrjjQ==",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.13.0.tgz",
+      "integrity": "sha512-Q2rtqmZWrbP8nePMq7mOJIN98M0fYvSgV89vwl/BQRT4mDOeY2GXZngfGpcBBhtky3woM7G24wZV3Q304Bv6cw==",
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.0"
       }
     },
     "node_modules/undici-types": {
@@ -5847,9 +5945,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -5898,9 +5996,9 @@
       "license": "MIT",
       "dependencies": {
         "@barry-bot/logger": "*",
-        "@discordjs/core": "^1.1.1",
-        "@discordjs/rest": "^2.2.0",
-        "@discordjs/ws": "^1.0.2",
+        "@discordjs/core": "^1.3.0-dev.1721153953-efa16a609",
+        "@discordjs/rest": "^2.4.0-dev.1721153952-efa16a609",
+        "@discordjs/ws": "^1.2.0-dev.1721153959-efa16a609",
         "fastify": "^4.15.0",
         "tweetnacl": "^1.0.3"
       },
@@ -5910,6 +6008,95 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "packages/core/node_modules/@discordjs/rest": {
+      "version": "2.4.0-dev.1721153952-efa16a609",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.4.0-dev.1721153952-efa16a609.tgz",
+      "integrity": "sha512-Nr7d5+4YXDALkNWESTF3ejizU+lVYyzIdMiu2I4+bNdhXozZzp/gZp8/Dk3O+LGRlDLO0foFJRk70UaMwjXmrQ==",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "0.37.90",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.2",
+        "undici": "6.18.2"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "packages/core/node_modules/@discordjs/rest/node_modules/undici": {
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.18.2.tgz",
+      "integrity": "sha512-o/MQLTwRm9IVhOqhZ0NQ9oXax1ygPjw6Vs+Vq/4QRjbOAC3B1GCHy7TYxxbExKlb7bzDRzt9vBWU6BDz0RFfYg==",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "packages/core/node_modules/@discordjs/ws": {
+      "version": "1.2.0-dev.1721153959-efa16a609",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.0-dev.1721153959-efa16a609.tgz",
+      "integrity": "sha512-Vo6HhS7R9F2jJV2rykLsloQPJKdiPR/PpHslFy192EgkOByiwC3JhL7+wzL6ATNitl6lsDTzQLwsPpMj1crbDA==",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.3.0",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "0.37.90",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "packages/core/node_modules/@discordjs/ws/node_modules/@discordjs/rest": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.3.0.tgz",
+      "integrity": "sha512-C1kAJK8aSYRv3ZwMG8cvrrW4GN0g5eMdP8AuN8ODH5DyOCbHgJspze1my3xHOAgwLJdKUbWNVyAeJ9cEdduqIg==",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "0.37.83",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.2",
+        "undici": "6.13.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "packages/core/node_modules/@discordjs/ws/node_modules/@discordjs/rest/node_modules/discord-api-types": {
+      "version": "0.37.83",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.83.tgz",
+      "integrity": "sha512-urGGYeWtWNYMKnYlZnOnDHm8fVRffQs3U0SpE8RHeiuLKb/u92APS8HoQnPTFbnXmY1vVnXjXO4dOxcAn3J+DA=="
+    },
+    "packages/core/node_modules/discord-api-types": {
+      "version": "0.37.90",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.90.tgz",
+      "integrity": "sha512-lpOJSGrqHuXoM4FV/2HtjoaJpCClGFHpRNIdZEW8zPINlsCHNSfIwA2EQ8dxeE6k1QhhTuM9ZlOGVYXoU7FLgA=="
+    },
+    "packages/core/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "packages/logger": {
       "name": "@barry-bot/logger",
@@ -5927,7 +6114,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@discordjs/core": "^1.1.1"
+        "@discordjs/core": "^1.3.0-dev.1721153953-efa16a609"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
       "dependencies": {
         "@barry-bot/core": "*",
         "@discordjs/core": "^1.3.0-dev.1721153953-efa16a609",
-        "@discordjs/rest": "^2.4.0-dev.1721153952-efa16a609",
+        "@discordjs/rest": "^2.3.0",
         "@discordjs/ws": "^1.2.0-dev.1721153959-efa16a609",
         "@napi-rs/canvas": "^0.1.41",
         "@prisma/client": "^5.0.0",
@@ -55,36 +55,6 @@
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "apps/barry/node_modules/@discordjs/rest": {
-      "version": "2.4.0-dev.1721153952-efa16a609",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.4.0-dev.1721153952-efa16a609.tgz",
-      "integrity": "sha512-Nr7d5+4YXDALkNWESTF3ejizU+lVYyzIdMiu2I4+bNdhXozZzp/gZp8/Dk3O+LGRlDLO0foFJRk70UaMwjXmrQ==",
-      "dependencies": {
-        "@discordjs/collection": "^2.1.0",
-        "@discordjs/util": "^1.1.0",
-        "@sapphire/async-queue": "^1.5.2",
-        "@sapphire/snowflake": "^3.5.3",
-        "@vladfrangu/async_event_emitter": "^2.2.4",
-        "discord-api-types": "0.37.90",
-        "magic-bytes.js": "^1.10.0",
-        "tslib": "^2.6.2",
-        "undici": "6.18.2"
-      },
-      "engines": {
-        "node": ">=16.11.0"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "apps/barry/node_modules/@discordjs/rest/node_modules/undici": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.18.2.tgz",
-      "integrity": "sha512-o/MQLTwRm9IVhOqhZ0NQ9oXax1ygPjw6Vs+Vq/4QRjbOAC3B1GCHy7TYxxbExKlb7bzDRzt9vBWU6BDz0RFfYg==",
-      "engines": {
-        "node": ">=18.17"
       }
     },
     "apps/barry/node_modules/@discordjs/ws": {
@@ -108,33 +78,6 @@
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
-    },
-    "apps/barry/node_modules/@discordjs/ws/node_modules/@discordjs/rest": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.3.0.tgz",
-      "integrity": "sha512-C1kAJK8aSYRv3ZwMG8cvrrW4GN0g5eMdP8AuN8ODH5DyOCbHgJspze1my3xHOAgwLJdKUbWNVyAeJ9cEdduqIg==",
-      "dependencies": {
-        "@discordjs/collection": "^2.1.0",
-        "@discordjs/util": "^1.1.0",
-        "@sapphire/async-queue": "^1.5.2",
-        "@sapphire/snowflake": "^3.5.3",
-        "@vladfrangu/async_event_emitter": "^2.2.4",
-        "discord-api-types": "0.37.83",
-        "magic-bytes.js": "^1.10.0",
-        "tslib": "^2.6.2",
-        "undici": "6.13.0"
-      },
-      "engines": {
-        "node": ">=16.11.0"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "apps/barry/node_modules/@discordjs/ws/node_modules/@discordjs/rest/node_modules/discord-api-types": {
-      "version": "0.37.83",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.83.tgz",
-      "integrity": "sha512-urGGYeWtWNYMKnYlZnOnDHm8fVRffQs3U0SpE8RHeiuLKb/u92APS8HoQnPTFbnXmY1vVnXjXO4dOxcAn3J+DA=="
     },
     "apps/barry/node_modules/discord-api-types": {
       "version": "0.37.90",
@@ -5997,7 +5940,7 @@
       "dependencies": {
         "@barry-bot/logger": "*",
         "@discordjs/core": "^1.3.0-dev.1721153953-efa16a609",
-        "@discordjs/rest": "^2.4.0-dev.1721153952-efa16a609",
+        "@discordjs/rest": "^2.3.0",
         "@discordjs/ws": "^1.2.0-dev.1721153959-efa16a609",
         "fastify": "^4.15.0",
         "tweetnacl": "^1.0.3"
@@ -6007,36 +5950,6 @@
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "packages/core/node_modules/@discordjs/rest": {
-      "version": "2.4.0-dev.1721153952-efa16a609",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.4.0-dev.1721153952-efa16a609.tgz",
-      "integrity": "sha512-Nr7d5+4YXDALkNWESTF3ejizU+lVYyzIdMiu2I4+bNdhXozZzp/gZp8/Dk3O+LGRlDLO0foFJRk70UaMwjXmrQ==",
-      "dependencies": {
-        "@discordjs/collection": "^2.1.0",
-        "@discordjs/util": "^1.1.0",
-        "@sapphire/async-queue": "^1.5.2",
-        "@sapphire/snowflake": "^3.5.3",
-        "@vladfrangu/async_event_emitter": "^2.2.4",
-        "discord-api-types": "0.37.90",
-        "magic-bytes.js": "^1.10.0",
-        "tslib": "^2.6.2",
-        "undici": "6.18.2"
-      },
-      "engines": {
-        "node": ">=16.11.0"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "packages/core/node_modules/@discordjs/rest/node_modules/undici": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.18.2.tgz",
-      "integrity": "sha512-o/MQLTwRm9IVhOqhZ0NQ9oXax1ygPjw6Vs+Vq/4QRjbOAC3B1GCHy7TYxxbExKlb7bzDRzt9vBWU6BDz0RFfYg==",
-      "engines": {
-        "node": ">=18.17"
       }
     },
     "packages/core/node_modules/@discordjs/ws": {
@@ -6060,33 +5973,6 @@
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
-    },
-    "packages/core/node_modules/@discordjs/ws/node_modules/@discordjs/rest": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.3.0.tgz",
-      "integrity": "sha512-C1kAJK8aSYRv3ZwMG8cvrrW4GN0g5eMdP8AuN8ODH5DyOCbHgJspze1my3xHOAgwLJdKUbWNVyAeJ9cEdduqIg==",
-      "dependencies": {
-        "@discordjs/collection": "^2.1.0",
-        "@discordjs/util": "^1.1.0",
-        "@sapphire/async-queue": "^1.5.2",
-        "@sapphire/snowflake": "^3.5.3",
-        "@vladfrangu/async_event_emitter": "^2.2.4",
-        "discord-api-types": "0.37.83",
-        "magic-bytes.js": "^1.10.0",
-        "tslib": "^2.6.2",
-        "undici": "6.13.0"
-      },
-      "engines": {
-        "node": ">=16.11.0"
-      },
-      "funding": {
-        "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "packages/core/node_modules/@discordjs/ws/node_modules/@discordjs/rest/node_modules/discord-api-types": {
-      "version": "0.37.83",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.83.tgz",
-      "integrity": "sha512-urGGYeWtWNYMKnYlZnOnDHm8fVRffQs3U0SpE8RHeiuLKb/u92APS8HoQnPTFbnXmY1vVnXjXO4dOxcAn3J+DA=="
     },
     "packages/core/node_modules/discord-api-types": {
       "version": "0.37.90",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,9 +24,9 @@
   },
   "dependencies": {
     "@barry-bot/logger": "*",
-    "@discordjs/core": "^1.1.1",
-    "@discordjs/rest": "^2.2.0",
-    "@discordjs/ws": "^1.0.2",
+    "@discordjs/core": "^1.3.0-dev.1721153953-efa16a609",
+    "@discordjs/rest": "^2.4.0-dev.1721153952-efa16a609",
+    "@discordjs/ws": "^1.2.0-dev.1721153959-efa16a609",
     "fastify": "^4.15.0",
     "tweetnacl": "^1.0.3"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@barry-bot/logger": "*",
     "@discordjs/core": "^1.3.0-dev.1721153953-efa16a609",
-    "@discordjs/rest": "^2.4.0-dev.1721153952-efa16a609",
+    "@discordjs/rest": "^2.3.0",
     "@discordjs/ws": "^1.2.0-dev.1721153959-efa16a609",
     "fastify": "^4.15.0",
     "tweetnacl": "^1.0.3"

--- a/packages/core/tests/commands/BaseCommand.test.ts
+++ b/packages/core/tests/commands/BaseCommand.test.ts
@@ -1,4 +1,9 @@
-import { type API, ApplicationCommandType } from "@discordjs/core";
+import {
+    type API,
+    ApplicationCommandType,
+    ApplicationIntegrationType,
+    InteractionContextType
+} from "@discordjs/core";
 import { type Module, Client } from "../../src/index.js";
 
 import { MockBaseCommand, MockModule, baseCommandOptions } from "../mocks/index.js";
@@ -22,10 +27,11 @@ describe("BaseCommand", () => {
 
             expect(command.appPermissions).toBe(baseCommandOptions.appPermissions);
             expect(command.client).toBe(client);
+            expect(command.contexts).toEqual(baseCommandOptions.contexts);
             expect(command.cooldown).toBe(baseCommandOptions.cooldown);
             expect(command.defaultMemberPermissions).toBe(baseCommandOptions.defaultMemberPermissions);
-            expect(command.guildOnly).toBe(baseCommandOptions.guildOnly);
             expect(command.guilds).toEqual(baseCommandOptions.guilds);
+            expect(command.integrationTypes).toEqual(baseCommandOptions.integrationTypes);
             expect(command.module).toBe(module);
             expect(command.name).toBe(baseCommandOptions.name);
             expect(command.nameLocalizations).toEqual(baseCommandOptions.nameLocalizations);
@@ -39,8 +45,53 @@ describe("BaseCommand", () => {
             });
 
             expect(command.cooldown).toBe(3);
-            expect(command.guildOnly).toBe(false);
             expect(command.ownerOnly).toBe(false);
+        });
+
+        it("should update 'guildOnly' for backward compatibility", () => {
+            const command = new MockBaseCommand(module, {
+                name: "test",
+                contexts: [InteractionContextType.Guild]
+            });
+
+            expect(command.contexts).toEqual([InteractionContextType.Guild]);
+            expect(command.guildOnly).toBe(true);
+        });
+
+        it("should update 'contexts' if 'guildOnly' is set to 'true'", () => {
+            const command = new MockBaseCommand(module, {
+                name: "test",
+                guildOnly: true
+            });
+
+            expect(command.contexts).toEqual([InteractionContextType.Guild]);
+            expect(command.guildOnly).toBe(true);
+        });
+
+        it("should update 'contexts' if 'guildOnly' is set to 'false'", () => {
+            const command = new MockBaseCommand(module, {
+                name: "test",
+                guildOnly: false
+            });
+
+            expect(command.contexts).toEqual([
+                InteractionContextType.Guild,
+                InteractionContextType.BotDM,
+                InteractionContextType.PrivateChannel
+            ]);
+            expect(command.guildOnly).toBe(false);
+        });
+
+        it("should log a warning if 'guildOnly' is used", () => {
+            const spy = vi.spyOn(console, "warn");
+
+            new MockBaseCommand(module, {
+                name: "test",
+                guildOnly: true
+            });
+
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spy).toHaveBeenCalledWith("The 'guildOnly' option is deprecated. Please use the 'contexts' option instead.");
         });
     });
 
@@ -50,8 +101,9 @@ describe("BaseCommand", () => {
             const payload = command.toJSON();
 
             expect(payload).toEqual({
+                contexts: [InteractionContextType.Guild],
                 default_member_permissions: "512",
-                dm_permission: false,
+                integration_types: [ApplicationIntegrationType.GuildInstall],
                 name: "test",
                 name_localizations: {
                   "en-US": "Test",
@@ -69,7 +121,6 @@ describe("BaseCommand", () => {
             const payload = command.toJSON();
 
             expect(payload).toEqual({
-                dm_permission: true,
                 name: "test",
                 type: ApplicationCommandType.ChatInput
             });

--- a/packages/core/tests/commands/SlashCommand.test.ts
+++ b/packages/core/tests/commands/SlashCommand.test.ts
@@ -1,7 +1,9 @@
 import {
     type API,
     ApplicationCommandOptionType,
-    ApplicationCommandType
+    ApplicationCommandType,
+    ApplicationIntegrationType,
+    InteractionContextType
 } from "@discordjs/core";
 import { type Module, Client } from "../../src/index.js";
 
@@ -78,10 +80,11 @@ describe("SlashCommand", () => {
             const payload = command.toJSON();
 
             expect(payload).toEqual({
+                contexts: [InteractionContextType.Guild],
                 default_member_permissions: "512",
                 description: slashCommandOptions.description,
                 description_localizations: slashCommandOptions.descriptionLocalizations,
-                dm_permission: !slashCommandOptions.guildOnly,
+                integration_types: [ApplicationIntegrationType.GuildInstall],
                 name: slashCommandOptions.name,
                 name_localizations: slashCommandOptions.nameLocalizations,
                 nsfw: slashCommandOptions.nsfw,
@@ -129,7 +132,6 @@ describe("SlashCommand", () => {
 
             expect(payload).toEqual({
                 description: "Mock command for testing purposes",
-                dm_permission: true,
                 name: "test",
                 options: [],
                 type: ApplicationCommandType.ChatInput

--- a/packages/core/tests/mocks/commands.ts
+++ b/packages/core/tests/mocks/commands.ts
@@ -1,4 +1,4 @@
-import { ApplicationCommandType } from "@discordjs/core";
+import { ApplicationCommandType, ApplicationIntegrationType, InteractionContextType } from "@discordjs/core";
 import {
     type ApplicationCommandOptions,
     type Module,
@@ -107,10 +107,11 @@ export class MockSlashCommandBar extends SlashCommand {
 
 export const baseCommandOptions: ApplicationCommandOptions = {
     appPermissions: 2112n,
+    contexts: [InteractionContextType.Guild],
     cooldown: 5,
     defaultMemberPermissions: 512n,
-    guildOnly: true,
     guilds: ["68239102456844360", "30527482987641765"],
+    integrationTypes: [ApplicationIntegrationType.GuildInstall],
     name: "test",
     nameLocalizations: {
         "en-US": "Test",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -24,6 +24,6 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@discordjs/core": "^1.1.1"
+    "@discordjs/core": "^1.3.0-dev.1721153953-efa16a609"
   }
 }

--- a/packages/testing/src/mocks/interactions/interactions.ts
+++ b/packages/testing/src/mocks/interactions/interactions.ts
@@ -8,6 +8,7 @@ import {
     type APIMessageComponentInteractionData,
     type APIModalSubmitInteraction,
     type APIPingInteraction,
+    ApplicationIntegrationType,
     InteractionType
 } from "@discordjs/core";
 
@@ -21,6 +22,9 @@ import { mockMessageButton } from "./components.js";
 const baseInteraction = {
     application_id: "49072635294295155",
     app_permissions: "8",
+    authorizing_integration_owners: {
+        [ApplicationIntegrationType.GuildInstall]: "68239102456844360"
+    },
     entitlements: [],
     guild_id: "68239102456844360",
     guild_locale: "en-US",


### PR DESCRIPTION
- Updates the `@discordjs/` packages to the dev release.
- Adds the option to make user-installable apps.
- Deprecates `guildOnly` (replaced by `contexts`).

